### PR TITLE
MovementStrategy: Adjust for some edge cases with the next-parallel strategy

### DIFF
--- a/puzlib/src/main/java/com/totsp/crossword/puz/MovementStrategy.java
+++ b/puzlib/src/main/java/com/totsp/crossword/puz/MovementStrategy.java
@@ -286,6 +286,22 @@ public interface MovementStrategy extends Serializable {
 							w.start.down + (w.across? 0 : w.length -1));
 					board.setHighlightLetter(end);
 					this.move(board, skipCompletedLetters);
+				} else {
+					//edge case - the move next on axis didn't move the position because the skipCompleted
+					//moved to the end of the word, and the next on axis tried to move onto a non-letter space
+					if (skipCompletedLetters && Common.isWordEnd(board.getHighlightLetter(), w)) {
+						if (board.skipCurrentBox(board.getCurrentBox(), skipCompletedLetters)) {
+							this.move(board, skipCompletedLetters);
+						}
+					} else {
+						Position newPos = board.getHighlightLetter();
+						if (p.across == newPos.across && p.down == newPos.down && !Common.isWordEnd(board.getHighlightLetter(), w)) {
+							Position end = new Position(w.start.across + (w.across ? w.length -1: 0),
+									w.start.down + (w.across? 0 : w.length -1));
+							board.setHighlightLetter(end);
+							this.move(board, skipCompletedLetters);
+						}
+					}
 				}
 			}
 


### PR DESCRIPTION
With the Next Parallel Clue movement strategy, there are some edge cases where the cursor was not moving to the next clue.  In particular, if the clue was along the bottom edge (for a down word) or the right edge (for an across word), the cursor would move only to the end of the clue on the same word.  Additionally, if the clue's end letter was not in the last row or column, but if there was a no-clue block (black box), then the cursor would not advance.

A deeper issue may be that the move methods in the Playboard class specifically continue to move in the same direction when the "next" box is null (non-clue/black box).  This fix only deals with the side effects in relation to the next parallel movement strategy in order to minimize the surface area of the change.