### PR TITLE
Show errors when word not selected

### DIFF
--- a/app/src/main/java/com/totsp/crossword/view/PlayboardRenderer.java
+++ b/app/src/main/java/com/totsp/crossword/view/PlayboardRenderer.java
@@ -316,7 +316,7 @@ public class PlayboardRenderer {
                 }
                 if ((highlight.across == col) && (highlight.down == row)) {
                     thisLetter = this.white;
-                } else if (inCurrentWord) {
+                } else {
                     thisLetter = red;
                 }
             }


### PR DESCRIPTION
Previously Shortyz showed errors when a word was selected but not when
unselected.