### PR TITLE
Do not fallthrough KEYCODE_ENTER

### DIFF
--- a/app/src/main/java/com/totsp/crossword/PlayActivity.java
+++ b/app/src/main/java/com/totsp/crossword/PlayActivity.java
@@ -850,11 +850,11 @@ public class PlayActivity extends ShortyzActivity {
                         previous = BOARD.nextWord();
                         this.render(previous);
                     }
-
-                    lastKey = System.currentTimeMillis();
-
-                    return true;
                 }
+
+                lastKey = System.currentTimeMillis();
+
+                return true;
 
             case KeyEvent.KEYCODE_DEL:
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,4 +19,9 @@ allprojects {
             url "http://dl.bintray.com/jenzz/maven"
         }
     }
+    gradle.projectsEvaluated {
+        tasks.withType(JavaCompile) {
+            options.compilerArgs << "-Xlint:fallthrough"
+        }
+    }
 }


### PR DESCRIPTION
Also enable `Xlint:fallthrough` to warn about this situation.