### PR TITLE
Upgrade to gradle 2.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0-alpha1'
+        classpath 'com.android.tools.build:gradle:2.1.2'
     }
 }
 


### PR DESCRIPTION
2.1.0-alpha1 does not exist in Maven Central.  Regression from
9b5d02e0cd5e8484033f7fed2898aaf4faa221f7.
