### PR TITLE
Check errors before cheats

### DIFF
--- a/app/src/main/java/com/totsp/crossword/view/PlayboardRenderer.java
+++ b/app/src/main/java/com/totsp/crossword/view/PlayboardRenderer.java
@@ -291,12 +291,12 @@ public class PlayboardRenderer {
                 canvas.drawRect(r, this.currentLetterHighlight);
             } else if ((currentWord != null) && currentWord.checkInWord(col, row)) {
                 canvas.drawRect(r, this.currentWordHighlight);
-            } else if (this.hintHighlight && box.isCheated()) {
-                canvas.drawRect(r, this.cheated);
             } else if (this.board.isShowErrors() && (box.getResponse() != ' ') &&
                     (box.getSolution() != box.getResponse())) {
                 box.setCheated(true);
                 canvas.drawRect(r, this.red);
+            } else if (this.hintHighlight && box.isCheated()) {
+                canvas.drawRect(r, this.cheated);
             } else {
                 canvas.drawRect(r, this.white);
             }
@@ -318,7 +318,7 @@ public class PlayboardRenderer {
                 }
                 if ((highlight.across == col) && (highlight.down == row)) {
                     thisLetter = this.white;
-                } else {
+                } else if (inCurrentWord) {
                     thisLetter = red;
                 }
             }


### PR DESCRIPTION
This ensures that incorrect letters display black text on red
background.  Also revert f8d543e740b7819e6842be044786f66d7ab2574f
which could incorrectly display red text on red background.