### PR TITLE
Fix in last word detection

### DIFF
--- a/puzlib/src/main/java/com/totsp/crossword/puz/MovementStrategy.java
+++ b/puzlib/src/main/java/com/totsp/crossword/puz/MovementStrategy.java
@@ -22,9 +22,9 @@ public interface MovementStrategy extends Serializable {
 		 */
 		static boolean isLastWordInDirection(Box[][] boxes, Word w) {
 			if (w.across) {
-				return (w.start.down + 1 >= boxes[w.start.across].length);
+				return (w.start.across + w.length >= boxes.length);
 			}
-			return (w.start.across + 1 >= boxes.length);
+			return (w.start.down + w.length >= boxes[w.start.across].length);
 		}
 
 		/**


### PR DESCRIPTION
Fixing a  problem with function to detect if the word is the last in its direction.  
Instead of checking the down coord for across words, across coord is used instead (and vice-versa). Also, the length of the word is added and not just 1.