### PR TITLE
Add an option to cleanup puzzle archives.

### DIFF
--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -24,11 +24,13 @@
      <string-array name="cleanupAgeLabels">
        <item>Two Days</item>
        <item>One Week</item>
+       <item>Thirty Days</item>
        <item>Never</item>
      </string-array>
      <string-array name="cleanupAgeValues">
        <item>2</item>
        <item>7</item>
+       <item>30</item>
        <item>-1</item>
      </string-array>
      <string-array name="orientationLockLabels">

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -212,9 +212,17 @@
 	
 	<ListPreference
 		android:title="Cleanup Unfinished"
-		android:summary="Determines how old an unfinished puzzle must be before it is archvied/deleted."
+		android:summary="Determines how old an unfinished puzzle must be before it is archived/deleted."
 		android:key="cleanupAge"
 		android:defaultValue="2"
+		android:entries="@array/cleanupAgeLabels"
+		android:entryValues="@array/cleanupAgeValues" />
+
+	<ListPreference
+		android:title="Cleanup Archives"
+		android:summary="Determines how old an archived puzzle must be before it is deleted."
+		android:key="archiveCleanupAge"
+		android:defaultValue="-1"
 		android:entries="@array/cleanupAgeLabels"
 		android:entryValues="@array/cleanupAgeValues" />
 	


### PR DESCRIPTION
This adds another option to delete crosswords from the archives
during "Cleanup" after a certain time. The default behavior is
unchanged.

This also removes an unused archiveMenuItem bit; the actual menu twiddling is taken care of in actionModeCallback.