### PR TITLE
Add a "Reveal" mode for "Errors".

### DIFF
--- a/app/src/main/java/com/totsp/crossword/ClueListAdapter.java
+++ b/app/src/main/java/com/totsp/crossword/ClueListAdapter.java
@@ -96,7 +96,7 @@ public class ClueListAdapter extends ArrayAdapter {
                 continue;
             }
 
-            sb.append((b.getResponse() == ' ') ? '_' : b.getResponse())
+            sb.append(b.isBlank() ? '_' : b.getResponse())
               .append(' ');
         }
 

--- a/app/src/main/java/com/totsp/crossword/PlayActivity.java
+++ b/app/src/main/java/com/totsp/crossword/PlayActivity.java
@@ -701,6 +701,7 @@ public class PlayActivity extends ShortyzActivity {
                     android.R.drawable.ic_menu_view);
             reveal.add(createSpannableForMenu("Letter")).setTitleCondensed("Letter");
             reveal.add(createSpannableForMenu("Word")).setTitleCondensed("Word");
+            reveal.add(createSpannableForMenu("Errors")).setTitleCondensed("Errors");
             reveal.add(createSpannableForMenu("Puzzle")).setTitleCondensed("Puzzle");
             if (ShortyzApplication.isTabletish(metrics)) {
                 utils.onActionBarWithText(reveal);
@@ -897,6 +898,11 @@ public class PlayActivity extends ShortyzActivity {
             return true;
         } else if (item.getTitle().toString().equals("Word")) {
             BOARD.revealWord();
+            this.render();
+
+            return true;
+        } else if (item.getTitle().toString().equals("Errors")) {
+            BOARD.revealErrors();
             this.render();
 
             return true;

--- a/app/src/main/java/com/totsp/crossword/view/PlayboardRenderer.java
+++ b/app/src/main/java/com/totsp/crossword/view/PlayboardRenderer.java
@@ -299,7 +299,7 @@ public class PlayboardRenderer {
                 canvas.drawRect(r, this.currentLetterHighlight);
             } else if ((currentWord != null) && currentWord.checkInWord(col, row)) {
                 canvas.drawRect(r, this.currentWordHighlight);
-            } else if (this.board.isShowErrors() && (box.getResponse() != ' ') &&
+            } else if (this.board.isShowErrors() && !box.isBlank() &&
                     (box.getSolution() != box.getResponse())) {
                 box.setCheated(true);
                 canvas.drawRect(r, this.red);
@@ -321,7 +321,7 @@ public class PlayboardRenderer {
             thisLetter = this.letterText;
 
             if (board.isShowErrors() && (box.getSolution() != box.getResponse())) {
-                if(box.getResponse() != ' '){
+                if (!box.isBlank()){
                     box.setCheated(true);
                 }
                 if ((highlight.across == col) && (highlight.down == row)) {

--- a/puzlib/src/main/java/com/totsp/crossword/io/IO.java
+++ b/puzlib/src/main/java/com/totsp/crossword/io/IO.java
@@ -436,8 +436,7 @@ public class IO {
 					tmpDos.writeByte('.');
 				} else {
 					byte val = (byte) boxes[x][y].getResponse(); // Character.toString().getBytes("Cp1252")[0];
-					tmpDos.writeByte((boxes[x][y].getResponse() == ' ') ? '-'
-							: val);
+					tmpDos.writeByte((boxes[x][y].isBlank()) ? '-' : val);
 				}
 			}
 		}

--- a/puzlib/src/main/java/com/totsp/crossword/puz/Box.java
+++ b/puzlib/src/main/java/com/totsp/crossword/puz/Box.java
@@ -3,12 +3,14 @@ package com.totsp.crossword.puz;
 import java.io.Serializable;
 
 public class Box implements Serializable {
+    private static final char BLANK = ' ';
+
     private String responder;
     private boolean across;
     private boolean cheated;
     private boolean down;
     private boolean circled;
-    private char response = ' ';
+    private char response = BLANK;
     private char solution;
     private int clueNumber;
 
@@ -200,4 +202,9 @@ public class Box implements Serializable {
     public String getResponder() {
         return responder;
     }
+
+    /**
+     * @return if the current box is blank
+     */
+    public boolean isBlank() { return getResponse() == BLANK; }
 }

--- a/puzlib/src/main/java/com/totsp/crossword/puz/MovementStrategy.java
+++ b/puzlib/src/main/java/com/totsp/crossword/puz/MovementStrategy.java
@@ -79,7 +79,7 @@ public interface MovementStrategy extends Serializable {
 					// special case if this is at the end of the board
 					Position current = board.getHighlightLetter();
 					Box[][] boxes = board.getBoxes();
-					if (boxes[current.across][current.down].getResponse() != ' ') {
+					if (!boxes[current.across][current.down].isBlank()) {
 						board.setHighlightLetter(p);
 					}
 				}

--- a/puzlib/src/main/java/com/totsp/crossword/puz/Playboard.java
+++ b/puzlib/src/main/java/com/totsp/crossword/puz/Playboard.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.function.Predicate;
 
 
 @SuppressWarnings({"WeakerAccess", "unused"})
@@ -355,7 +356,7 @@ public class Playboard implements Serializable {
         Box currentBox = this.boxes[this.highlightLetter.across][this.highlightLetter.down];
         Word wordToReturn = this.getCurrentWord();
 
-        if (currentBox.getResponse() == ' ') {
+        if (currentBox.isBlank()) {
             wordToReturn = this.previousLetter();
             currentBox = this.boxes[this.highlightLetter.across][this.highlightLetter.down];
         }
@@ -596,6 +597,34 @@ public class Playboard implements Serializable {
         return null;
     }
 
+    /**
+     * Reveals the correct answers for any "red" squares on the board.
+     *
+     * This covers hidden and visible incorrect responses, as well as squares that are marked as
+     * "cheated" from previously erased incorrect responses.
+     *
+     * @return
+     */
+    public List<Position> revealErrors() {
+        ArrayList<Position> changes = new ArrayList<Position>();
+
+        for (int across = 0; across < this.boxes.length; across++) {
+            for (int down = 0; down < this.boxes[across].length; down++) {
+                Box b = this.boxes[across][down];
+                if (b == null) { continue; }
+
+                if (b.isCheated() ||
+                        (!b.isBlank() && (b.getSolution() != b.getResponse()))) {
+                    b.setCheated(true);
+                    b.setResponse(b.getSolution());
+                    changes.add(new Position(across, down));
+                }
+            }
+        }
+
+        return changes;
+    }
+
     public List<Position> revealPuzzle() {
         ArrayList<Position> changes = new ArrayList<Position>();
 
@@ -636,7 +665,7 @@ public class Playboard implements Serializable {
     }
 
     public boolean skipCurrentBox(Box b, boolean skipCompleted) {
-        return skipCompleted && (b.getResponse() != ' ') &&
+        return skipCompleted && !b.isBlank() &&
         (!this.isShowErrors() || (b.getResponse() == b.getSolution()));
     }
 

--- a/puzlib/src/main/java/com/totsp/crossword/puz/Puzzle.java
+++ b/puzlib/src/main/java/com/totsp/crossword/puz/Puzzle.java
@@ -275,7 +275,7 @@ public class Puzzle implements Serializable{
                 if (boxes[x][y] != null) {
                     total++;
 
-                    if (boxes[x][y].getResponse() != ' ') {
+                    if (!boxes[x][y].isBlank()) {
                         filled++;
                     }
                 }


### PR DESCRIPTION
If "Show Errors" is enabled, this fills in the correct anwswer in all "red" boxes.

If "Show Errors" is disabled, this fills in the correct answer in any currently incorrect boxes, and marks those boxes "red".

This also refactors checking for "blank" squares into a helper method.