### PR TITLE
Upgrade to Gradle plugin 2.3.0 and Gradle 3.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-alpha2'
+        classpath 'com.android.tools.build:gradle:2.3.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-milestone-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
This addresses failures:

```
The android gradle plugin version 3.0.0-alpha2 is too old, please update to the latest version.
```

and:

```
> Failed to apply plugin [id 'com.android.application']
   > Minimum supported Gradle version is 3.3. Current version is 3.2. If using the gradle wrapper, try editing the distributionUrl in /home/gaul/work/shortyz/gradle/wrapper/gradle-wrapper.properties to gradle-3.3-all.zip
```