### PR TITLE
Implement clue list positioning suggestions from issue #101

### DIFF
--- a/puzlib/src/main/java/com/totsp/crossword/puz/Playboard.java
+++ b/puzlib/src/main/java/com/totsp/crossword/puz/Playboard.java
@@ -221,11 +221,11 @@ public class Playboard implements Serializable {
         return clues;
     }
 
-    public Word setHighlightLetter(Position highlightLetter) {
+    public Word setHighlightLetter(Position highlightLetter, boolean toggle) {
         Word w = this.getCurrentWord();
 
         if (highlightLetter.equals(this.highlightLetter)) {
-            this.toggleDirection();
+            if (toggle) this.toggleDirection();
         } else {
             if ((this.boxes.length > highlightLetter.across) && (highlightLetter.across >= 0) &&
                     (this.boxes[highlightLetter.across].length > highlightLetter.down) && (highlightLetter.down >= 0) &&
@@ -235,6 +235,10 @@ public class Playboard implements Serializable {
         }
 
         return w;
+    }
+
+    public Word setHighlightLetter(Position highlightLetter) {
+      return setHighlightLetter(highlightLetter, true);
     }
 
     public Position getHighlightLetter() {
@@ -678,6 +682,22 @@ public class Playboard implements Serializable {
 
     public void toggleShowErrors() {
         this.showErrors = !this.showErrors;
+    }
+
+    // find next blank or error (if showing errors), starting scan at current position
+    public Position getNextBlankOrError() {
+        int across = this.highlightLetter.across;
+        int down   = this.highlightLetter.down;
+        Box b;
+
+        while (across < this.puzzle.getWidth() && down < this.puzzle.getHeight()) {
+            b = this.boxes[across][down];
+            if (b == null) return null;
+            if (!skipCurrentBox(b, true)) return new Position(across, down);
+            if (this.isAcross()) across++; else down++;
+        }
+
+        return null;
     }
 
     public static class Clue implements Serializable {


### PR DESCRIPTION
Implements items from issue #101.

 - When the clue list is first entered, position the list to the entry that was current on the play board.
 - When moving to a different clue in the clue list, position the highlight to the first non-blank letter in the word. If none, then position to the first letter.
 - Add menu bar items on the clue list to scroll to the next or previous unsolved clue in the list.
 - Make left/right arrow movement in the clue list not be dependent on the current movement strategy set in the play board.

This is my first contribution so please give feedback on style or anything else.

Thanks
