### PR TITLE
Add support for periodically downloading puzzles in the background.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
     <uses-permission android:name="android.permission.USE_CREDENTIALS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <uses-feature
         android:name="android.hardware.touchscreen"
@@ -119,6 +120,12 @@
                 <action android:name="android.intent.action.DOWNLOAD_COMPLETE" />
             </intent-filter>
         </receiver>
+
+        <service
+            android:name="com.totsp.crossword.BackgroundDownloadService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="true">
+        </service>
 
         <activity
             android:name="com.totsp.crossword.GamesSignIn"

--- a/app/src/main/java/com/totsp/crossword/BackgroundDownloadService.java
+++ b/app/src/main/java/com/totsp/crossword/BackgroundDownloadService.java
@@ -1,0 +1,156 @@
+package com.totsp.crossword;
+
+import android.Manifest;
+import android.annotation.TargetApi;
+import android.app.NotificationManager;
+import android.app.job.JobInfo;
+import android.app.job.JobParameters;
+import android.app.job.JobScheduler;
+import android.app.job.JobService;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.os.AsyncTask;
+import android.os.Looper;
+import android.preference.PreferenceManager;
+import android.support.v4.content.ContextCompat;
+
+import com.totsp.crossword.net.Downloaders;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+// Currently only available on API version >=21 due to use of JobScheduler.
+// It may be possible to implement this functionality using AlarmManager for lower SDK versions.
+@TargetApi(21)
+public class BackgroundDownloadService extends JobService {
+    public static final String DOWNLOAD_PENDING_PREFERENCE = "backgroundDlPending";
+
+    private static final Logger LOGGER =
+            Logger.getLogger(BackgroundDownloadService.class.getCanonicalName());
+
+    private static JobInfo getJobInfo(boolean requireUnmetered, boolean allowRoaming,
+                                      boolean requireCharging) {
+        JobInfo.Builder builder = new JobInfo.Builder(
+                JobSchedulerId.BACKGROUND_DOWNLOAD.id(),
+                new ComponentName("com.totsp.crossword.shortyz",
+                        BackgroundDownloadService.class.getName()));
+
+        builder.setPeriodic(TimeUnit.HOURS.toMillis(1))
+                .setRequiredNetworkType(JobInfo.NETWORK_TYPE_UNMETERED)
+                .setRequiresCharging(requireCharging)
+                .setPersisted(true);
+
+        if (!requireUnmetered) {
+            if (allowRoaming) {
+                builder.setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY);
+            } else {
+                builder.setRequiredNetworkType(JobInfo.NETWORK_TYPE_NOT_ROAMING);
+            }
+        }
+
+        return builder.build();
+    }
+
+    @Override
+    public boolean onStartJob(JobParameters job) {
+        LOGGER.info("Starting background download task");
+        DownloadTask downloadTask = new DownloadTask(this);
+        downloadTask.execute(job);
+        return true;
+    }
+
+    @Override
+    public boolean onStopJob(JobParameters job) {
+        return false;
+    }
+
+    public static void updateJob(Context context) {
+        SharedPreferences preferences =
+                PreferenceManager.getDefaultSharedPreferences(context);
+
+        boolean enable = preferences.getBoolean("backgroundDownload", false);
+
+        if (enable) {
+            scheduleJob(context);
+        } else {
+            cancelJob(context);
+        }
+    }
+
+    private static void scheduleJob(Context context) {
+        JobScheduler scheduler =
+                (JobScheduler)context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
+
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+
+        JobInfo info = getJobInfo(
+                preferences.getBoolean("backgroundDownloadRequireUnmetered", true),
+                preferences.getBoolean("backgroundDownloadAllowRoaming", false),
+                preferences.getBoolean("backgroundDownloadRequireCharging", false));
+
+
+        LOGGER.info("Scheduling background download job: " + info);
+
+        int result = scheduler.schedule(info);
+
+        if (result == JobScheduler.RESULT_SUCCESS) {
+            LOGGER.info("Successfully scheduled background downloads");
+        } else {
+            LOGGER.log(Level.WARNING, "Unable to schedule background downloads");
+        }
+    }
+
+    private static void cancelJob(Context context) {
+        LOGGER.info("Unscheduling background downloads");
+        JobScheduler scheduler =
+                (JobScheduler)context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
+        scheduler.cancel(JobSchedulerId.BACKGROUND_DOWNLOAD.id());
+    }
+
+    private static class DownloadTask extends AsyncTask<JobParameters, Void, JobParameters> {
+        private final JobService jobService;
+
+        public DownloadTask(JobService jobService) {
+            this.jobService = jobService;
+        }
+
+        @Override
+        protected JobParameters doInBackground(JobParameters... params) {
+            Context context = jobService.getApplicationContext();
+
+            NotificationManager nm =
+                    (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+
+            if (ContextCompat.checkSelfPermission(context,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE) !=
+                    PackageManager.PERMISSION_GRANTED) {
+                LOGGER.info("Skipping download, no write permission");
+                return params[0];
+            }
+
+            LOGGER.info("Downloading most recent puzzles");
+
+            Looper.prepare();
+
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+            final Downloaders dls = new Downloaders(prefs, nm, context, false);
+            dls.downloadLatestIfNewerThanDate(new Date(), null);
+
+            // This is used to tell BrowseActivity that puzzles may have been updated while
+            // paused.
+            prefs.edit()
+                .putBoolean(DOWNLOAD_PENDING_PREFERENCE, true)
+                .apply();
+
+            return params[0];
+        }
+
+        protected void onPostExecute(JobParameters params) {
+            jobService.jobFinished(params, false);
+        }
+    }
+}

--- a/app/src/main/java/com/totsp/crossword/BrowseActivity.java
+++ b/app/src/main/java/com/totsp/crossword/BrowseActivity.java
@@ -552,6 +552,15 @@ public class BrowseActivity extends ShortyzActivity implements RecyclerItemClick
             }
         }
 
+
+
+        // A background update will commonly happen when the user turns on the preference for the
+        // first time, so check here to ensure the UI is re-rendered when they exit the settings
+        // dialog.
+        if (utils.checkBackgroundDownload(prefs, hasWritePermissions)) {
+            render();
+        }
+
         this.checkDownload();
     }
 
@@ -667,8 +676,8 @@ public class BrowseActivity extends ShortyzActivity implements RecyclerItemClick
                 ((System.currentTimeMillis() - (long) (12 * 60 * 60 * 1000)) > lastDL)) {
             this.download(new Date(), null, true);
             prefs.edit()
-                 .putLong("dlLast", System.currentTimeMillis())
-                 .apply();
+                    .putLong("dlLast", System.currentTimeMillis())
+                    .apply();
         }
     }
 
@@ -812,6 +821,8 @@ public class BrowseActivity extends ShortyzActivity implements RecyclerItemClick
 
     private void render() {
         if (!hasWritePermissions) return;
+
+        utils.clearBackgroundDownload(prefs);
 
         if ((this.sources != null) && (this.sources.getAdapter() == null)) {
             final SourceListAdapter adapter = new SourceListAdapter(this, this.sourceList);

--- a/app/src/main/java/com/totsp/crossword/JobSchedulerId.java
+++ b/app/src/main/java/com/totsp/crossword/JobSchedulerId.java
@@ -1,0 +1,20 @@
+package com.totsp.crossword;
+
+// All JobScheduler Job IDs for this application.
+//
+// Using an enum here since all jobs scheduled by the same uid (not just package) need to be unique.
+//
+// These need to be stable across app updates.
+public enum JobSchedulerId {
+    BACKGROUND_DOWNLOAD(10);
+
+    private int id;
+
+    JobSchedulerId(int id) {
+        this.id = id;
+    }
+
+    int id() {
+        return this.id;
+    }
+}

--- a/app/src/main/java/com/totsp/crossword/PreferencesActivity.java
+++ b/app/src/main/java/com/totsp/crossword/PreferencesActivity.java
@@ -1,6 +1,8 @@
 package com.totsp.crossword;
 
+import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
 import android.preference.Preference;
@@ -13,12 +15,21 @@ import com.totsp.crossword.firstrun.FirstrunActivity;
 import com.totsp.crossword.gmail.GMConstants;
 import com.totsp.crossword.shortyz.R;
 import com.totsp.crossword.shortyz.ShortyzApplication;
+import com.totsp.crossword.versions.AndroidVersionUtils;
 
 
-public class PreferencesActivity extends PreferenceActivity {
+public class PreferencesActivity extends PreferenceActivity
+        implements SharedPreferences.OnSharedPreferenceChangeListener {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         addPreferencesFromResource(R.xml.preferences);
+
+        if (!AndroidVersionUtils.Factory.getInstance().isBackgroundDownloadAvaliable()) {
+            Preference backgroundDownload = findPreference("backgroundDownload");
+            backgroundDownload.setSelectable(false);
+            backgroundDownload.setEnabled(false);
+            backgroundDownload.setSummary("Requires Android Lollipop or later");
+        }
 
         findPreference("releaseNotes")
                 .setOnPreferenceClickListener(new OnPreferenceClickListener() {
@@ -99,7 +110,7 @@ public class PreferencesActivity extends PreferenceActivity {
                 return true;
             }
         });
-        
+
 //        Preference sendDebug = (Preference) findPreference("sendDebug");
 //        sendDebug.setOnPreferenceClickListener(new OnPreferenceClickListener(){
 //
@@ -109,5 +120,28 @@ public class PreferencesActivity extends PreferenceActivity {
 //			}
 //        	
 //        });
+    }
+
+    protected void onResume() {
+        PreferenceManager.getDefaultSharedPreferences(this)
+                .registerOnSharedPreferenceChangeListener(this);
+        super.onResume();
+    }
+
+    protected void onPause() {
+        PreferenceManager.getDefaultSharedPreferences(this)
+                .unregisterOnSharedPreferenceChangeListener(this);
+        super.onPause();
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String pref) {
+        if (pref.equals("backgroundDownload") ||
+                pref.equals("backgroundDownloadRequireUnmetered") ||
+                pref.equals("backgroundDownloadAllowRoaming") ||
+                pref.equals("backgroundDownloadRequireCharging")) {
+            Context context = PreferencesActivity.this.getApplicationContext();
+            BackgroundDownloadService.updateJob(context);
+        }
     }
 }

--- a/app/src/main/java/com/totsp/crossword/net/Downloaders.java
+++ b/app/src/main/java/com/totsp/crossword/net/Downloaders.java
@@ -1,6 +1,5 @@
 package com.totsp.crossword.net;
 
-import android.app.Activity;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -15,7 +14,6 @@ import com.totsp.crossword.BrowseActivity;
 import com.totsp.crossword.PlayActivity;
 import com.totsp.crossword.gmail.GmailDownloader;
 import com.totsp.crossword.io.IO;
-import com.totsp.crossword.nyt.ErrorActivity;
 import com.totsp.crossword.puz.Puzzle;
 import com.totsp.crossword.puz.PuzzleMeta;
 import com.totsp.crossword.shortyz.ShortyzApplication;
@@ -26,176 +24,232 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class Downloaders {
-	private static final Logger LOG = Logger.getLogger("com.totsp.crossword");
-	private Context context;
-	private List<Downloader> downloaders = new LinkedList<Downloader>();
-	private NotificationManager notificationManager;
-	private boolean supressMessages;
+    private static final Logger LOG = Logger.getLogger("com.totsp.crossword");
+    private Context context;
+    private List<Downloader> downloaders = new LinkedList<Downloader>();
+    private NotificationManager notificationManager;
+    private boolean supressMessages;
 
-	public Downloaders(SharedPreferences prefs,
-			NotificationManager notificationManager, Activity context) {
-		this.notificationManager = notificationManager;
-		this.context = context;
+    // Set isInteractive to true if this class can ask for user interaction when needed (e.g. to
+    // refresh NYT credentials), false if otherwise.
+    public Downloaders(SharedPreferences prefs,
+                       NotificationManager notificationManager,
+                       Context context,
+                       boolean isInteractive) {
+        this.notificationManager = notificationManager;
+        this.context = context;
 
-//		if (prefs.getBoolean("downloadGlobe", true)) {
-//			downloaders.add(new OldBostonGlobeDownloader());
-//		}
+//        if (prefs.getBoolean("downloadGlobe", true)) {
+//            downloaders.add(new OldBostonGlobeDownloader());
+//        }
 //
-//		if (prefs.getBoolean("downloadThinks", true)) {
-//			downloaders.add(new ThinksDownloader());
-//		}
-//		if (prefs.getBoolean("downloadWaPo", true)) {
-//		 downloaders.add(new WaPoDownloader());
-//		 }
-		
-		if (prefs.getBoolean("downloadWsj", true)) {
-			downloaders.add(new WSJFridayDownloader());
-			downloaders.add(new WSJSaturdayDownloader());
-		}
+//        if (prefs.getBoolean("downloadThinks", true)) {
+//            downloaders.add(new ThinksDownloader());
+//        }
+//        if (prefs.getBoolean("downloadWaPo", true)) {
+//         downloaders.add(new WaPoDownloader());
+//         }
+        
+        if (prefs.getBoolean("downloadWsj", true)) {
+            downloaders.add(new WSJFridayDownloader());
+            downloaders.add(new WSJSaturdayDownloader());
+        }
 
-		if (prefs.getBoolean("downloadWaPoPuzzler", true)) {
-			downloaders.add(new WaPoPuzzlerDownloader());
-		}
+        if (prefs.getBoolean("downloadWaPoPuzzler", true)) {
+            downloaders.add(new WaPoPuzzlerDownloader());
+        }
 
-//		if (prefs.getBoolean("downloadNYTClassic", true)) {
-//			downloaders.add(new NYTClassicDownloader());
-//		}
+//        if (prefs.getBoolean("downloadNYTClassic", true)) {
+//            downloaders.add(new NYTClassicDownloader());
+//        }
 
-//		if (prefs.getBoolean("downloadInkwell", true)) {
-//			downloaders.add(new InkwellDownloader());
-//		}
+//        if (prefs.getBoolean("downloadInkwell", true)) {
+//            downloaders.add(new InkwellDownloader());
+//        }
 
-		if (prefs.getBoolean("downloadJonesin", true)) {
-			downloaders.add(new JonesinDownloader());
-		}
+        if (prefs.getBoolean("downloadJonesin", true)) {
+            downloaders.add(new JonesinDownloader());
+        }
 
-		if (prefs.getBoolean("downloadLat", true)) {
-//			downloaders.add(new UclickDownloader("tmcal", "Los Angeles Times", "Rich Norris", Downloader.DATE_NO_SUNDAY));
-			downloaders.add(new LATimesDownloader());
-		}
+        if (prefs.getBoolean("downloadLat", true)) {
+//           downloaders.add(new UclickDownloader("tmcal", "Los Angeles Times", "Rich Norris", Downloader.DATE_NO_SUNDAY));
+            downloaders.add(new LATimesDownloader());
+        }
 
-//		if (prefs.getBoolean("downloadAvClub", true)) {
-//			downloaders.add(new AVClubDownloader());
-//		}
+//        if (prefs.getBoolean("downloadAvClub", true)) {
+//            downloaders.add(new AVClubDownloader());
+//        }
 
-//		if (prefs.getBoolean("downloadPhilly", true)) {
-//			downloaders.add(new PhillyDownloader());
-//		}
+//        if (prefs.getBoolean("downloadPhilly", true)) {
+//            downloaders.add(new PhillyDownloader());
+//        }
 
-		if (prefs.getBoolean("downloadCHE", true)) {
-			downloaders.add(new CHEDownloader());
-		}
+        if (prefs.getBoolean("downloadCHE", true)) {
+            downloaders.add(new CHEDownloader());
+        }
 
-		if (prefs.getBoolean("downloadJoseph", true)) {
-			downloaders.add(new KFSDownloader("joseph", "Joseph Crosswords",
-					"Thomas Joseph", Downloader.DATE_NO_SUNDAY));
-		}
+        if (prefs.getBoolean("downloadJoseph", true)) {
+            downloaders.add(new KFSDownloader("joseph", "Joseph Crosswords",
+                    "Thomas Joseph", Downloader.DATE_NO_SUNDAY));
+        }
 
-		if (prefs.getBoolean("downloadSheffer", true)) {
-			downloaders.add(new KFSDownloader("sheffer", "Sheffer Crosswords",
-					"Eugene Sheffer", Downloader.DATE_NO_SUNDAY));
-		}
+        if (prefs.getBoolean("downloadSheffer", true)) {
+            downloaders.add(new KFSDownloader("sheffer", "Sheffer Crosswords",
+                    "Eugene Sheffer", Downloader.DATE_NO_SUNDAY));
+        }
 
-//		if (prefs.getBoolean("downloadPremier", true)) {
-//			downloaders.add(new KFSDownloader("premier", "Premier Crosswords",
-//					"Frank Longo", Downloader.DATE_SUNDAY));
-//		}
+//        if (prefs.getBoolean("downloadPremier", true)) {
+//            downloaders.add(new KFSDownloader("premier", "Premier Crosswords",
+//                    "Frank Longo", Downloader.DATE_SUNDAY));
+//        }
 
-		if (prefs.getBoolean("downloadNewsday", true)) {
-			downloaders.add(new BrainsOnlyDownloader(
+        if (prefs.getBoolean("downloadNewsday", true)) {
+            downloaders.add(new BrainsOnlyDownloader(
                     "http://brainsonly.com/servlets-newsday-crossword/newsdaycrossword?date=",
                     "Newsday"));
-		}
+        }
 
-		if (prefs.getBoolean("downloadUSAToday", true)) {
-			downloaders.add(new UclickDownloader("usaon", "USA Today",
-					"USA Today", Downloader.DATE_NO_SUNDAY));
-		}
+        if (prefs.getBoolean("downloadUSAToday", true)) {
+            downloaders.add(new UclickDownloader("usaon", "USA Today",
+                    "USA Today", Downloader.DATE_NO_SUNDAY));
+        }
 
-		if (prefs.getBoolean("downloadUniversal", true)) {
-			downloaders.add(new UclickDownloader("fcx", "Universal Crossword",
-					"uclick LLC", Downloader.DATE_DAILY));
-		}
+        if (prefs.getBoolean("downloadUniversal", true)) {
+            downloaders.add(new UclickDownloader("fcx", "Universal Crossword",
+                    "uclick LLC", Downloader.DATE_DAILY));
+        }
 
-		if (prefs.getBoolean("downloadLACal", true)) {
-			downloaders.add(new LATSundayDownloader());
-		}
+        if (prefs.getBoolean("downloadLACal", true)) {
+            downloaders.add(new LATSundayDownloader());
+        }
 
-//		if (prefs.getBoolean("downloadISwear", true)) {
-//			downloaders.add(new ISwearDownloader());
-//		}
-		
-		
-		if (prefs.getBoolean("downloadNYT", false)) {
-			if(!prefs.getBoolean("didNYTLogin", false)){
-				Intent i = new Intent(context, ErrorActivity.class);
-				context.startActivity(i);
-			}
-			downloaders.add(new NYTDownloader(context));
+//        if (prefs.getBoolean("downloadISwear", true)) {
+//            downloaders.add(new ISwearDownloader());
+//        }
+        
+        
+        if (prefs.getBoolean("downloadNYT", false)) {
+            NYTDownloader nyt;
+            if (isInteractive) {
+                nyt = new NYTDownloader(context);
+                nyt.requestCredentialsIfNeeded();
+            } else {
+                nyt = new NYTDownloader(context, notificationManager);
+            }
+            downloaders.add(nyt);
 
-		}
+        }
 
-		ShortyzApplication application = (ShortyzApplication) context.getApplication();
-		System.out.println("Doing GMAIL: " + application.getGmailService() != null);
-		if(application.getGmailService() != null){
-			downloaders.add(new GmailDownloader(application.getGmailService()));
-		}
+        ShortyzApplication application = (ShortyzApplication) context.getApplicationContext();
+        System.out.println("Doing GMAIL: " + application.getGmailService() != null);
+        if(application.getGmailService() != null){
+            downloaders.add(new GmailDownloader(application.getGmailService()));
+        }
 
 
-		this.supressMessages = prefs.getBoolean("supressMessages", false);
-	}
+        this.supressMessages = prefs.getBoolean("supressMessages", false);
+    }
 
-	public List<Downloader> getDownloaders(Date date) {
-		int dayOfWeek = date.getDay();
-		List<Downloader> retVal = new LinkedList<Downloader>();
+    public Downloaders(SharedPreferences prefs,
+                       NotificationManager notificationManager,
+                       Context context) {
+        this(prefs, notificationManager, context, true);
+    }
 
-		for (Downloader d : downloaders) {
-			if (Arrays.binarySearch(d.getDownloadDates(), dayOfWeek) >= 0) {
-				if(date.getTime() >= d.getGoodFrom().getTime() && date.getTime() <= d.getGoodThrough().getTime()) {
-					retVal.add(d);
-				}
-			}
-		}
-
-		return retVal;
-	}
-
-	public void download(Date date) {
-		download(date, getDownloaders(date));
-	}
-
-	public void download(Date date, List<Downloader> downloaders) {
+    private static Date clearTimeInDate(Date date) {
         Calendar cal = Calendar.getInstance();
-        Calendar now = Calendar.getInstance();
         cal.setTime(date);
         cal.set(Calendar.HOUR_OF_DAY, 0);
         cal.set(Calendar.MINUTE, 0);
         cal.set(Calendar.SECOND, 0);
         cal.set(Calendar.MILLISECOND, 0);
+        return cal.getTime();
+    }
 
-        date = cal.getTime();
-        now.setTimeInMillis(System.currentTimeMillis());
+    public List<Downloader> getDownloaders(Date date) {
+        date = clearTimeInDate(date);
+        int dayOfWeek = date.getDay();
+        List<Downloader> retVal = new LinkedList<Downloader>();
 
-        now.set(Calendar.MINUTE, 0);
-        now.set(Calendar.SECOND, 0);
-        now.set(Calendar.MILLISECOND, 0);
-        now.set(Calendar.HOUR_OF_DAY, 0);
+        for (Downloader d : downloaders) {
+            // TODO: Downloader.getGoodThrough() should account for the day of week.
+            if (Arrays.binarySearch(d.getDownloadDates(), dayOfWeek) >= 0) {
+                if(date.getTime() >= d.getGoodFrom().getTime() && date.getTime() <= d.getGoodThrough().getTime()) {
+                    retVal.add(d);
+                }
+            }
+        }
 
-        int i = 1;
+        return retVal;
+    }
+
+    public void download(Date date) {
+        download(date, getDownloaders(date));
+    }
+
+    // Downloads the latest puzzles newer/equal to than the given date for the given set of
+    // downloaders.
+    //
+    // If downloaders is null, then the full list of downloaders will be used.
+    public void downloadLatestIfNewerThanDate(Date oldestDate, List<Downloader> downloaders) {
+        oldestDate = clearTimeInDate(oldestDate);
+
+        if (downloaders == null) {
+            downloaders = new ArrayList<Downloader>();
+        }
+
+        if (downloaders.size() == 0) {
+            downloaders.addAll(this.downloaders);
+        }
+
+        HashMap<Downloader, Date> puzzlesToDownload = new HashMap<Downloader, Date>();
+        for (Downloader d : downloaders) {
+            Date goodThrough = clearTimeInDate(d.getGoodThrough());
+            int goodThroughDayOfWeek = goodThrough.getDay();
+            if ((Arrays.binarySearch(d.getDownloadDates(), goodThroughDayOfWeek) >= 0) &&
+                    goodThrough.getTime() >= oldestDate.getTime()) {
+                LOG.info("Will try to download puzzle " + d + " @ " + goodThrough);
+                puzzlesToDownload.put(d, goodThrough);
+            }
+        }
+
+        if (!puzzlesToDownload.isEmpty()) {
+            download(puzzlesToDownload);
+        }
+    }
+
+    public void download(Date date, List<Downloader> downloaders) {
+        date = clearTimeInDate(date);
+
+        if ((downloaders == null) || (downloaders.size() == 0)) {
+            downloaders = getDownloaders(date);
+        }
+
+        HashMap<Downloader, Date> puzzlesToDownload = new HashMap<Downloader, Date>();
+        for (Downloader d : downloaders) {
+            puzzlesToDownload.put(d, date);
+        }
+
+        download(puzzlesToDownload);
+    }
+
+    private void download(Map<Downloader, Date> puzzlesToDownload) {
         String contentTitle = "Downloading Puzzles";
 
-		NotificationCompat.Builder not =
-				new NotificationCompat.Builder(context)
-				.setSmallIcon(android.R.drawable.stat_sys_download)
-				.setContentTitle(contentTitle)
-				.setWhen(System.currentTimeMillis());
+        NotificationCompat.Builder not =
+                new NotificationCompat.Builder(context)
+                        .setSmallIcon(android.R.drawable.stat_sys_download)
+                        .setContentTitle(contentTitle)
+                        .setWhen(System.currentTimeMillis());
 
         boolean somethingDownloaded = false;
         File crosswords = new File(Environment.getExternalStorageDirectory(), "crosswords/");
@@ -205,77 +259,27 @@ public class Downloaders {
         if (crosswords.listFiles() != null) {
             for (File isDel : crosswords.listFiles()) {
                 if (isDel.getName()
-                             .endsWith(".tmp")) {
+                        .endsWith(".tmp")) {
                     isDel.delete();
                 }
             }
         }
 
-        if ((downloaders == null) || (downloaders.size() == 0)) {
-            downloaders = getDownloaders(date);
-        }
-
         HashSet<File> newlyDownloaded = new HashSet<File>();
 
-        for (Downloader d : downloaders) {
-			LOG.info("Downloading "+d.toString());
-            d.setContext(context);
-
-            try {
-                String contentText = "Downloading from " + d.getName();
-                Intent notificationIntent = new Intent(context, PlayActivity.class);
-                PendingIntent contentIntent = PendingIntent.getActivity(context, 0, notificationIntent, 0);
-
-				not.setContentText(contentText).setContentIntent(contentIntent);
-
-                if (!this.supressMessages && this.notificationManager != null) {
-                    this.notificationManager.notify(0, not.build());
-                }
-
-                File downloaded = new File(crosswords, d.createFileName(date));
-                File archived = new File(archive, d.createFileName(date));
-
-                System.out.println(downloaded.getAbsolutePath() + " " + downloaded.exists() + " OR " +
-                    archived.getAbsolutePath() + " " + archived.exists());
-
-                if (!d.alwaysRun() && (downloaded.exists() || archived.exists())) {
-					System.out.println("==Skipping "+d.toString());
-                    continue;
-                }
-
-                downloaded = d.download(date);
-
-                if (downloaded == Downloader.DEFERRED_FILE) {
-                    continue;
-                }
-
-                if (downloaded != null) {
-                	boolean updatable = false;
-
-                    //                    if (d instanceof NYTDownloader &&
-                    //                            (date.getTime() >= now.getTimeInMillis())) {
-                    //                        updatable = true;
-                    //                    }
-                    PuzzleMeta meta = new PuzzleMeta();
-                    meta.date = date;
-                    meta.source = d.getName();
-                    meta.sourceUrl = d.sourceUrl(date);
-                    meta.updatable = updatable;
-
-                    if (processDownloadedPuzzle(downloaded, meta)) {
-                        if (!this.supressMessages) {
-                            this.postDownloadedNotification(i, d.getName(), downloaded);
-                        }
-
-                        newlyDownloaded.add(downloaded);
-                        somethingDownloaded = true;
-                    }
-                }
-
-                i++;
-            } catch (Exception e) {
-               LOG.log(Level.WARNING, "Failed to download "+d.getName(), e);
+        int nextNotificationId = 1;
+        for (Map.Entry<Downloader, Date> puzzle : puzzlesToDownload.entrySet()) {
+            File downloaded = downloadPuzzle(puzzle.getKey(),
+                    puzzle.getValue(),
+                    not,
+                    nextNotificationId++,
+                    crosswords,
+                    archive);
+            if (downloaded != null) {
+                somethingDownloaded = true;
+                newlyDownloaded.add(downloaded);
             }
+
         }
 
         { // DO UPDATES
@@ -285,9 +289,9 @@ public class Downloaders {
             try {
                 for (File file : crosswords.listFiles()) {
                     if (file.getName()
-                                .endsWith(".shortyz")) {
+                            .endsWith(".shortyz")) {
                         File puz = new File(file.getAbsolutePath().substring(0,
-                                    file.getAbsolutePath().lastIndexOf('.') + 1) + "puz");
+                                file.getAbsolutePath().lastIndexOf('.') + 1) + "puz");
                         System.out.println(puz.getAbsolutePath());
 
                         if (!newlyDownloaded.contains(puz)) {
@@ -300,9 +304,9 @@ public class Downloaders {
 
                 for (File file : archive.listFiles()) {
                     if (file.getName()
-                                .endsWith(".shortyz")) {
+                            .endsWith(".shortyz")) {
                         checkUpdate.add(new File(file.getAbsolutePath().substring(0,
-                                    file.getAbsolutePath().lastIndexOf('.') + 1) + "puz"));
+                                file.getAbsolutePath().lastIndexOf('.') + 1) + "puz"));
                     }
                 }
             } catch (Exception e) {
@@ -337,98 +341,154 @@ public class Downloaders {
         if (somethingDownloaded) {
             this.postDownloadedGeneral();
         }
-        
-        
     }
 
-	public static boolean processDownloadedPuzzle(File downloaded,
-			PuzzleMeta meta) {
-		try {
-			System.out.println("==PROCESSING " + downloaded + " hasmeta: "
-					+ (meta != null));
+    private File downloadPuzzle(Downloader d,
+                                Date date,
+                                NotificationCompat.Builder not,
+                                int notificationId,
+                                File crosswords,
+                                File archive) {
+        LOG.info("Downloading " + d.toString());
+        d.setContext(context);
 
-			Puzzle puz = IO.load(downloaded);
-			if(puz == null){
-				return false;
-			}
-			puz.setDate(meta.date);
-			puz.setSource(meta.source);
-			puz.setSourceUrl(meta.sourceUrl);
-			puz.setUpdatable(meta.updatable);
+        try {
+            String contentText = "Downloading from " + d.getName();
+            Intent notificationIntent = new Intent(context, PlayActivity.class);
+            PendingIntent contentIntent = PendingIntent.getActivity(context, 0, notificationIntent, 0);
 
-			IO.save(puz, downloaded);
+            not.setContentText(contentText).setContentIntent(contentIntent);
 
-			return true;
-		} catch (Exception ioe) {
-			LOG.log(Level.WARNING, "Exception reading " + downloaded, ioe);
-			downloaded.delete();
+            File downloaded = new File(crosswords, d.createFileName(date));
+            File archived = new File(archive, d.createFileName(date));
 
-			return false;
-		}
-	}
+            System.out.println(downloaded.getAbsolutePath() + " " + downloaded.exists() + " OR " +
+                    archived.getAbsolutePath() + " " + archived.exists());
 
-	public void supressMessages(boolean b) {
-		this.supressMessages = b;
-	}
+            if (!d.alwaysRun() && (downloaded.exists() || archived.exists())) {
+                System.out.println("==Skipping " + d.toString());
+                return null;
+            }
 
-	private void postDownloadedGeneral() {
-		String contentTitle = "Downloaded new puzzles!";
+            if (!this.supressMessages && this.notificationManager != null) {
+                this.notificationManager.notify(0, not.build());
+            }
 
-		Intent notificationIntent = new Intent(Intent.ACTION_EDIT, null,
-				context, BrowseActivity.class);
-		PendingIntent contentIntent = PendingIntent.getActivity(context, 0,
-				notificationIntent, 0);
+            downloaded = d.download(date);
 
-		Notification not = new NotificationCompat.Builder(context)
-				.setSmallIcon(android.R.drawable.stat_sys_download_done)
-				.setContentTitle(contentTitle)
-				.setContentText("New puzzles were downloaded.")
-				.setContentIntent(contentIntent)
-				.setWhen(System.currentTimeMillis())
-				.build();
+            if (downloaded == Downloader.DEFERRED_FILE) {
+                return null;
+            }
 
-		if (this.notificationManager != null) {
-			this.notificationManager.notify(0, not);
-		}
-	}
+            if (downloaded != null) {
+                boolean updatable = false;
+                PuzzleMeta meta = new PuzzleMeta();
+                meta.date = date;
+                meta.source = d.getName();
+                meta.sourceUrl = d.sourceUrl(date);
+                meta.updatable = updatable;
 
-	private void postDownloadedNotification(int i, String name, File puzFile) {
-		String contentTitle = "Downloaded " + name;
+                if (processDownloadedPuzzle(downloaded, meta)) {
+                    if (!this.supressMessages) {
+                        this.postDownloadedNotification(notificationId, d.getName(), downloaded);
+                    }
 
-		Intent notificationIntent = new Intent(Intent.ACTION_EDIT,
-				Uri.fromFile(puzFile), context, PlayActivity.class);
-		PendingIntent contentIntent = PendingIntent.getActivity(context, 0,
-				notificationIntent, 0);
+                    return downloaded;
+                }
+            }
+        } catch (Exception e) {
+            LOG.log(Level.WARNING, "Failed to download "+d.getName(), e);
+            return null;
+        }
+        return null;
+    }
 
-		Notification not = new NotificationCompat.Builder(context)
-				.setSmallIcon(android.R.drawable.stat_sys_download_done)
-				.setContentTitle(contentTitle)
-				.setContentText(puzFile.getName())
-				.setContentIntent(contentIntent)
-				.setWhen(System.currentTimeMillis())
-				.build();
+    public static boolean processDownloadedPuzzle(File downloaded,
+            PuzzleMeta meta) {
+        try {
+            System.out.println("==PROCESSING " + downloaded + " hasmeta: "
+                    + (meta != null));
 
-		if (this.notificationManager != null) {
-			this.notificationManager.notify(i, not);
-		}
-	}
+            Puzzle puz = IO.load(downloaded);
+            if(puz == null){
+                return false;
+            }
+            puz.setDate(meta.date);
+            puz.setSource(meta.source);
+            puz.setSourceUrl(meta.sourceUrl);
+            puz.setUpdatable(meta.updatable);
 
-//	private void postUpdatedNotification(int i, String name, File puzFile) {
-//		String contentTitle = "Updated " + name;
-//		Notification not = new Notification(
-//				android.R.drawable.stat_sys_download_done, contentTitle,
-//				System.currentTimeMillis());
-//		Intent notificationIntent = new Intent(Intent.ACTION_EDIT,
-//				Uri.fromFile(puzFile), context, PlayActivity.class);
-//		PendingIntent contentIntent = PendingIntent.getActivity(context, 0,
-//				notificationIntent, 0);
-//		not.setLatestEventInfo(context, contentTitle, puzFile.getName(),
-//				contentIntent);
+            IO.save(puz, downloaded);
+
+            return true;
+        } catch (Exception ioe) {
+            LOG.log(Level.WARNING, "Exception reading " + downloaded, ioe);
+            downloaded.delete();
+
+            return false;
+        }
+    }
+
+    public void supressMessages(boolean b) {
+        this.supressMessages = b;
+    }
+
+    private void postDownloadedGeneral() {
+        String contentTitle = "Downloaded new puzzles!";
+
+        Intent notificationIntent = new Intent(Intent.ACTION_EDIT, null,
+                context, BrowseActivity.class);
+        PendingIntent contentIntent = PendingIntent.getActivity(context, 0,
+                notificationIntent, 0);
+
+        Notification not = new NotificationCompat.Builder(context)
+                .setSmallIcon(android.R.drawable.stat_sys_download_done)
+                .setContentTitle(contentTitle)
+                .setContentText("New puzzles were downloaded.")
+                .setContentIntent(contentIntent)
+                .setWhen(System.currentTimeMillis())
+                .build();
+
+        if (this.notificationManager != null) {
+            this.notificationManager.notify(0, not);
+        }
+    }
+
+    private void postDownloadedNotification(int i, String name, File puzFile) {
+        String contentTitle = "Downloaded " + name;
+
+        Intent notificationIntent = new Intent(Intent.ACTION_EDIT,
+                Uri.fromFile(puzFile), context, PlayActivity.class);
+        PendingIntent contentIntent = PendingIntent.getActivity(context, 0,
+                notificationIntent, 0);
+
+        Notification not = new NotificationCompat.Builder(context)
+                .setSmallIcon(android.R.drawable.stat_sys_download_done)
+                .setContentTitle(contentTitle)
+                .setContentText(puzFile.getName())
+                .setContentIntent(contentIntent)
+                .setWhen(System.currentTimeMillis())
+                .build();
+
+        if (this.notificationManager != null) {
+            this.notificationManager.notify(i, not);
+        }
+    }
+
+//    private void postUpdatedNotification(int i, String name, File puzFile) {
+//        String contentTitle = "Updated " + name;
+//        Notification not = new Notification(
+//                android.R.drawable.stat_sys_download_done, contentTitle,
+//                System.currentTimeMillis());
+//        Intent notificationIntent = new Intent(Intent.ACTION_EDIT,
+//                Uri.fromFile(puzFile), context, PlayActivity.class);
+//        PendingIntent contentIntent = PendingIntent.getActivity(context, 0,
+//                notificationIntent, 0);
+//        not.setLatestEventInfo(context, contentTitle, puzFile.getName(),
+//                contentIntent);
 //
-//		if ((this.notificationManager != null) && !supressMessages) {
-//			this.notificationManager.notify(i, not);
-//		}
-//	}
-
-	
+//        if ((this.notificationManager != null) && !supressMessages) {
+//            this.notificationManager.notify(i, not);
+//        }
+//    }
 }

--- a/app/src/main/java/com/totsp/crossword/net/NYTDownloader.java
+++ b/app/src/main/java/com/totsp/crossword/net/NYTDownloader.java
@@ -1,8 +1,11 @@
 package com.totsp.crossword.net;
 
+import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.preference.PreferenceManager;
+import android.support.v4.app.NotificationCompat;
 
 import com.totsp.crossword.io.IO;
 import com.totsp.crossword.nyt.ErrorActivity;
@@ -34,15 +37,28 @@ public class NYTDownloader extends AbstractDownloader {
             "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
     public static final String NAME = "New York Times";
     private static final String PUZZLES_PAGE_URL = "https://www.nytimes.com/crosswords/index.html?page=home&_r=0";
+
+    private static final String NOTIFICATION_TAG = "NYTDownloader";
+    private static final int LOGIN_NOTIFICATION_ID = 1;
+
     NumberFormat nf = NumberFormat.getInstance();
     private Context context;
     private HashMap<String, String> params = new HashMap<String, String>();
+    private NotificationManager nm;
 
-    public NYTDownloader(Context context) {
+    // When we attempt to download a puzzle and our NYT credentials are out of date, if nm is null,
+    // immediately enter the login workflow.  If nm is not null, instead of launching the login
+    // workflow, post a notification to the user which can be used to log in at their convenience.
+    public NYTDownloader(Context context, NotificationManager nm) {
         super("https://www.nytimes.com/svc/crosswords/v2/puzzle/", DOWNLOAD_DIR, NAME);
         this.context = context;
         nf.setMinimumIntegerDigits(2);
         nf.setMaximumFractionDigits(0);
+        this.nm = nm;
+    }
+
+    public NYTDownloader(Context context) {
+        this(context, null);
     }
 
     public int[] getDownloadDates() {
@@ -70,16 +86,31 @@ public class NYTDownloader extends AbstractDownloader {
 
     @Override
     protected File download(Date date, String urlSuffix) {
+        // At the moment, clearing NYT credentials just sets the didNYTLogin preference to false,
+        // and doesn't actually clear the credentials.  This means that if we don't gate the
+        // download with a request for credentials, we could successfully download (using the old
+        // credentials) when this is not intended by the user.
+        //
+        // For non-background downloads, we do this request when creating the set of downloaders by
+        // not providing a NotificationManager.  During non-interactive downloads (e.g. automatic
+        // background downloads), we don't, so add the check here in order to avoid a confusing
+        // state where we notify both that we need a login but successfully download a puzzle.
+        //
+        // Likely, we want to consolidate the behavior for both cases, as there's a similar problem
+        // when we launch the login workflow (if you skip the credential screen, the puzzle still
+        // downloads successfully).
+        if ((nm != null) && requestCredentialsIfNeeded()) {
+            return null;
+        }
+
         try {
             URL url = new URL(this.baseUrl + urlSuffix);
             OkHttpClient client = this.createClient();
-
 
             Request request = new Request.Builder()
                     .url(url)
                     .header("Referer", PUZZLES_PAGE_URL)
                     .build();
-
 
             Response response = client.newCall(request).execute();
 
@@ -87,8 +118,7 @@ public class NYTDownloader extends AbstractDownloader {
                 PreferenceManager.getDefaultSharedPreferences(context).edit()
                         .putBoolean("didNYTLogin", false)
                         .apply();
-                Intent i = new Intent(context, ErrorActivity.class);
-                context.startActivity(i);
+                requestCredentialsIfNeeded();
                 return null;
             }
             if (response.code() == 200) {
@@ -133,5 +163,34 @@ public class NYTDownloader extends AbstractDownloader {
                 .build();
 
         return httpclient;
+    }
+
+    // Returns true if credentials are needed and a request was made, false if credentials were
+    // not needed.
+    public boolean requestCredentialsIfNeeded() {
+        if(PreferenceManager.getDefaultSharedPreferences(context).getBoolean(
+                "didNYTLogin", false)) {
+            return false;
+        }
+
+        Intent loginIntent = new Intent(context, ErrorActivity.class);
+
+        if (nm == null) {
+            context.startActivity(loginIntent);
+        } else {
+            PendingIntent contentIntent = PendingIntent.getActivity(
+                    context, 0, loginIntent, 0);
+            NotificationCompat.Builder builder =
+                    new NotificationCompat.Builder(this.context)
+                            .setSmallIcon(android.R.drawable.stat_notify_error)
+                            .setContentTitle("Unable to download New York Times puzzles")
+                            .setContentText("Click to log in again")
+                            .setAutoCancel(true)
+                            .setContentIntent(contentIntent)
+                            .setWhen(System.currentTimeMillis());
+            nm.notify(NOTIFICATION_TAG, LOGIN_NOTIFICATION_ID, builder.build());
+        }
+
+        return true;
     }
 }

--- a/app/src/main/java/com/totsp/crossword/versions/AndroidVersionUtils.java
+++ b/app/src/main/java/com/totsp/crossword/versions/AndroidVersionUtils.java
@@ -1,7 +1,9 @@
 package com.totsp.crossword.versions;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.net.Uri;
+import android.os.Build;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 import android.view.SubMenu;
@@ -43,13 +45,16 @@ public interface AndroidVersionUtils {
 			System.out.println("Creating utils for version: "
 					+ android.os.Build.VERSION.SDK_INT);
 
-			switch (android.os.Build.VERSION.SDK_INT) {
-			case 10:
-			case 9:
-				System.out.println("Using Gingerbread.");
-				return INSTANCE = new GingerbreadUtil();
-			default:
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+				System.out.println("Using Lollipop");
+				return INSTANCE = new LollipopUtil();
+			}
+			else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+				System.out.println("Using Honeycomb");
 				return INSTANCE = new HoneycombUtil();
+			} else {
+				System.out.println("Using Gingerbread");
+				return INSTANCE = new GingerbreadUtil();
 			}
 		}
 	}
@@ -68,5 +73,15 @@ public interface AndroidVersionUtils {
 
 	boolean isNightModeAvailable();
 
-	
+	// This has a dependency on JobScheduler which is only available in SDK version 21.
+	//
+	// TODO: It might be possible to replicate this functionality on older versions using
+	// AlarmManager.
+	boolean isBackgroundDownloadAvaliable();
+
+	// Checks whether a background download may have updated the available puzzles, requiring a
+	// UI refresh.
+	boolean checkBackgroundDownload(SharedPreferences prefs, boolean hasWritePermissions);
+
+	void clearBackgroundDownload(SharedPreferences prefs);
 }

--- a/app/src/main/java/com/totsp/crossword/versions/DefaultUtil.java
+++ b/app/src/main/java/com/totsp/crossword/versions/DefaultUtil.java
@@ -1,6 +1,7 @@
 package com.totsp.crossword.versions;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.net.Uri;
 import android.support.v7.app.ActionBarActivity;
 import android.support.v7.app.AppCompatActivity;
@@ -78,4 +79,10 @@ public abstract class DefaultUtil implements AndroidVersionUtils {
     public abstract void onActionBarWithoutText(MenuItem a);
 
     public abstract void hideTitleOnPortrait(AppCompatActivity a);
+
+	public abstract boolean isBackgroundDownloadAvaliable();
+
+	public abstract boolean checkBackgroundDownload(SharedPreferences prefs, boolean hasWritePermissions);
+
+	public abstract void clearBackgroundDownload(SharedPreferences prefs);
 }

--- a/app/src/main/java/com/totsp/crossword/versions/GingerbreadUtil.java
+++ b/app/src/main/java/com/totsp/crossword/versions/GingerbreadUtil.java
@@ -1,6 +1,7 @@
 package com.totsp.crossword.versions;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.net.Uri;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
@@ -56,6 +57,21 @@ public class GingerbreadUtil extends DefaultUtil {
     }
 
     public void hideTitleOnPortrait(AppCompatActivity a) {
+
+    }
+
+    @Override
+    public boolean isBackgroundDownloadAvaliable() {
+        return false;
+    }
+
+    @Override
+    public boolean checkBackgroundDownload(SharedPreferences prefs, boolean hasWritePermissions) {
+        return false;
+    }
+
+    @Override
+    public void clearBackgroundDownload(SharedPreferences prefs) {
 
     }
 

--- a/app/src/main/java/com/totsp/crossword/versions/LollipopUtil.java
+++ b/app/src/main/java/com/totsp/crossword/versions/LollipopUtil.java
@@ -1,0 +1,34 @@
+package com.totsp.crossword.versions;
+
+import android.content.SharedPreferences;
+
+import com.totsp.crossword.BackgroundDownloadService;
+
+public class LollipopUtil extends HoneycombUtil {
+
+    @Override
+    public boolean isBackgroundDownloadAvaliable() {
+        return true;
+    }
+
+    @Override
+    public boolean checkBackgroundDownload(SharedPreferences prefs, boolean hasWritePermissions) {
+        if (!hasWritePermissions) {
+            return false;
+        }
+
+        boolean isPending =
+                prefs.getBoolean(BackgroundDownloadService.DOWNLOAD_PENDING_PREFERENCE, false);
+
+        clearBackgroundDownload(prefs);
+
+        return isPending;
+    }
+
+    @Override
+    public void clearBackgroundDownload(SharedPreferences prefs) {
+        prefs.edit()
+                .putBoolean(BackgroundDownloadService.DOWNLOAD_PENDING_PREFERENCE, false)
+                .apply();
+    }
+}

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen
   xmlns:android="http://schemas.android.com/apk/res/android">
- 
+
 <com.jenzz.materialpreference.PreferenceCategory
 	android:title="Select Puzzle Sources">
 	<!-- Organized alphabetically and by category. -->
@@ -181,7 +181,41 @@
 		android:summary="Download today's puzzles when starting the application"
 		android:key="dlOnStartup"
 	/>
-	
+
+	<com.jenzz.materialpreference.CheckBoxPreference
+		android:title="Download new puzzles in background"
+		android:summary="Periodically download new puzzles in the background, even when Shortyz is not in use."
+		android:key="backgroundDownload"
+		android:defaultValue="false"
+		/>
+
+	<PreferenceScreen
+		android:title="Background Download Options"
+		android:summary="Configure background downloads."
+		android:dependency="backgroundDownload"
+		android:key="backgroundDownloadOptions">
+		<com.jenzz.materialpreference.CheckBoxPreference
+			android:title="Download over Wifi only"
+			android:defaultValue="true"
+			android:disableDependentsState="true"
+			android:summaryOn="Only schedule background downloads when Wifi is available."
+			android:summaryOff="Schedule background downloads even when not on Wifi"
+			android:key="backgroundDownloadRequireUnmetered" />
+		<com.jenzz.materialpreference.CheckBoxPreference
+			android:title="Download when roaming"
+			android:defaultValue="false"
+			android:dependency="backgroundDownloadRequireUnmetered"
+			android:summaryOn="Schedule background downloads when roaming"
+			android:summaryOff="Do not schedule background downloads when roaming"
+			android:key="backgroundDownloadAllowRoaming" />
+		<com.jenzz.materialpreference.CheckBoxPreference
+			android:title="Download while charging only"
+			android:defaultValue="false"
+			android:summaryOn="Only schedule background downloads when charging"
+			android:summaryOff="Schedule background downloads when on battery"
+			android:key="backgroundDownloadRequireCharging" />
+	</PreferenceScreen>
+
 	<com.jenzz.materialpreference.CheckBoxPreference
 		android:title="No Download Notifications"
 		android:defaultValue="false"

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-alpha2'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 


### PR DESCRIPTION
This is implemented by using JobScheduler to periodically download puzzles that the user has selected. JobScheduler is only available on API version >=21, so  this functionality is disabled for lower API versions.

Using the JobScheduler API allows us to easily provide options for downloading on wifi only, when charging, etc.

Currently just attempt to download every hour. There are more intelligent things we can do here, but this has been working well on my device.

The updated NYT authentication mechanism is supported by posting a notification requesting login when a background download fails instead of immediately launching the login activity.

A slight refactor of Downloaders was required to allow for downloading the most recent the most recent puzzle for each source instead of just the puzzle for the current (or specified) date.  This is intended to work in concert with PR #88 which allows the NYT puzzles to be available before the puzzle date.

I'm not too familiar with Android development, and was having a hard time coming up with a way to unit test these changes.  I'm open to adding some if you have some suggestions for how to do so.