### PR TITLE
New feature: notes page

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -88,7 +88,12 @@
             android:label="Clues"
             android:theme="@style/Theme.Shortyz"
             android:configChanges="orientation"
-            />
+        />
+        <activity
+            android:name="com.totsp.crossword.NotesActivity"
+            android:label="Notes"
+            android:theme="@style/Theme.Shortyz"
+        />
         <activity
             android:name="com.totsp.crossword.HTMLActivity"
             android:label="Shortyz"

--- a/app/src/main/java/com/totsp/crossword/ClueListActivity.java
+++ b/app/src/main/java/com/totsp/crossword/ClueListActivity.java
@@ -11,6 +11,7 @@ import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.util.DisplayMetrics;
 import android.view.KeyEvent;
+import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
@@ -74,6 +75,10 @@ public class ClueListActivity extends ShortyzActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         if(item == null || item.getItemId() == android.R.id.home) {
             finish();
+            return true;
+        } else if (item.getTitle().toString().equals("Notes")) {
+            Intent i = new Intent(ClueListActivity.this, NotesActivity.class);
+            ClueListActivity.this.startActivityForResult(i, 0);
             return true;
         } else {
             return super.onOptionsItemSelected(item);
@@ -316,6 +321,12 @@ public class ClueListActivity extends ShortyzActivity {
 			}
 		});
 		this.render();
+	}
+
+	@Override
+	public boolean onCreateOptionsMenu(Menu menu) {
+		menu.add("Notes").setIcon(android.R.drawable.ic_menu_agenda);
+		return true;
 	}
 
 	@Override

--- a/app/src/main/java/com/totsp/crossword/NotesActivity.java
+++ b/app/src/main/java/com/totsp/crossword/NotesActivity.java
@@ -1,0 +1,650 @@
+package com.totsp.crossword;
+
+import static com.totsp.crossword.shortyz.ShortyzApplication.BOARD;
+import static com.totsp.crossword.shortyz.ShortyzApplication.RENDERER;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Random;
+import java.util.logging.Logger;
+
+import android.os.Bundle;
+import android.net.Uri;
+import android.widget.EditText;
+import android.widget.TextView;
+import android.util.TypedValue;
+import android.view.MenuItem;
+import android.support.v4.content.ContextCompat;
+import android.util.DisplayMetrics;
+import android.view.KeyEvent;
+import android.view.View;
+import android.view.View.OnFocusChangeListener;
+import android.inputmethodservice.Keyboard;
+import android.inputmethodservice.KeyboardView;
+import android.inputmethodservice.KeyboardView.OnKeyboardActionListener;
+import android.content.Intent;
+import android.content.res.Configuration;
+import android.widget.Toast;
+import android.view.inputmethod.InputMethodManager;
+import android.content.Context;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
+
+import com.totsp.crossword.io.IO;
+import com.totsp.crossword.shortyz.R;
+import com.totsp.crossword.puz.Playboard.Clue;
+import com.totsp.crossword.puz.Puzzle;
+import com.totsp.crossword.puz.Note;
+import com.totsp.crossword.view.BoardEditText;
+import com.totsp.crossword.view.BoardEditText.BoardEditFilter;
+import com.totsp.crossword.shortyz.ShortyzApplication;
+import com.totsp.crossword.view.PlayboardRenderer;
+import com.totsp.crossword.view.ScrollingImageView;
+import com.totsp.crossword.view.ScrollingImageView.ClickListener;
+import com.totsp.crossword.puz.Playboard.Word;
+import com.totsp.crossword.puz.Playboard.Position;
+import com.totsp.crossword.view.ScrollingImageView.Point;
+import com.totsp.crossword.puz.Playboard.Word;
+import com.totsp.crossword.puz.Box;
+
+public class NotesActivity extends ShortyzActivity {
+    private static final Logger LOG = Logger.getLogger(NotesActivity.class.getCanonicalName());
+
+	protected Configuration configuration;
+	protected File baseFile;
+	protected ImaginaryTimer timer;
+	protected KeyboardView keyboardView = null;
+	protected Puzzle puz;
+	private ScrollingImageView imageView;
+	private BoardEditText scratchView;
+	private BoardEditText anagramSourceView;
+	private BoardEditText anagramSolView;
+	private boolean useNativeKeyboard = false;
+	private PlayboardRenderer renderer;
+
+	private Random rand = new Random();
+
+	private int numAnagramLetters = 0;
+
+	@Override
+	public void onConfigurationChanged(Configuration newConfig) {
+		super.onConfigurationChanged(newConfig);
+		this.configuration = newConfig;
+		try {
+			if (this.prefs.getBoolean("forceKeyboard", false)
+					|| (this.configuration.hardKeyboardHidden == Configuration.HARDKEYBOARDHIDDEN_YES)
+					|| (this.configuration.hardKeyboardHidden == Configuration.HARDKEYBOARDHIDDEN_UNDEFINED)) {
+				InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+
+				if (imm != null)
+					imm.toggleSoftInput(InputMethodManager.SHOW_FORCED,
+							InputMethodManager.HIDE_NOT_ALWAYS);
+
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+
+	@Override
+	public boolean onOptionsItemSelected(MenuItem item) {
+		if(item == null || item.getItemId() == android.R.id.home) {
+			finish();
+			return true;
+		} else {
+			return super.onOptionsItemSelected(item);
+		}
+	}
+
+	@Override
+	public void onCreate(Bundle icicle) {
+		super.onCreate(icicle);
+		utils.holographic(this);
+		utils.finishOnHomeButton(this);
+		DisplayMetrics metrics = new DisplayMetrics();
+		getWindowManager().getDefaultDisplay().getMetrics(metrics);
+		this.renderer = new PlayboardRenderer(ShortyzApplication.BOARD, metrics.densityDpi, metrics.widthPixels,
+				!prefs.getBoolean("supressHints", false),
+				ContextCompat.getColor(this, R.color.boxColor), ContextCompat.getColor(this, R.color.blankColor),
+				ContextCompat.getColor(this, R.color.errorColor));
+
+		try {
+			this.configuration = getBaseContext().getResources()
+					.getConfiguration();
+		} catch (Exception e) {
+			Toast.makeText(this, "Unable to read device configuration.",
+					Toast.LENGTH_LONG).show();
+			finish();
+		}
+		if(ShortyzApplication.BOARD == null || ShortyzApplication.BOARD.getPuzzle() == null){
+			finish();
+			return;
+		}
+		this.timer = new ImaginaryTimer(
+				ShortyzApplication.BOARD.getPuzzle().getTime());
+
+		Uri u = this.getIntent().getData();
+
+		if (u != null) {
+			if (u.getScheme().equals("file")) {
+				baseFile = new File(u.getPath());
+			}
+		}
+
+		puz = ShortyzApplication.BOARD.getPuzzle();
+		timer.start();
+
+		setContentView(R.layout.notes);
+
+		int keyboardType = "CONDENSED_ARROWS".equals(prefs.getString(
+				"keyboardType", "")) ? R.xml.keyboard_dpad : R.xml.keyboard;
+		Keyboard keyboard = new Keyboard(this, keyboardType);
+		keyboardView = (KeyboardView) this.findViewById(R.id.notesKeyboard);
+		keyboardView.setKeyboard(keyboard);
+		this.useNativeKeyboard = "NATIVE".equals(prefs.getString(
+				"keyboardType", ""));
+
+		if (this.useNativeKeyboard) {
+			keyboardView.setVisibility(View.GONE);
+		}
+
+		keyboardView
+				.setOnKeyboardActionListener(new OnKeyboardActionListener() {
+					private long lastSwipe = 0;
+
+					public void onKey(int primaryCode, int[] keyCodes) {
+						long eventTime = System.currentTimeMillis();
+
+						if ((eventTime - lastSwipe) < 500) {
+							return;
+						}
+
+						KeyEvent event = new KeyEvent(eventTime, eventTime,
+								KeyEvent.ACTION_DOWN, primaryCode, 0, 0, 0, 0,
+								KeyEvent.FLAG_SOFT_KEYBOARD
+										| KeyEvent.FLAG_KEEP_TOUCH_MODE);
+						NotesActivity.this.onKeyUp(primaryCode, event);
+					}
+
+					public void onPress(int primaryCode) {}
+
+					public void onRelease(int primaryCode){}
+
+					public void onText(CharSequence text) {}
+
+					public void swipeDown() {}
+
+					public void swipeLeft() {
+						long eventTime = System.currentTimeMillis();
+						lastSwipe = eventTime;
+
+						KeyEvent event = new KeyEvent(eventTime, eventTime,
+								KeyEvent.ACTION_DOWN,
+								KeyEvent.KEYCODE_DPAD_LEFT, 0, 0, 0, 0,
+								KeyEvent.FLAG_SOFT_KEYBOARD
+										| KeyEvent.FLAG_KEEP_TOUCH_MODE);
+						NotesActivity.this.onKeyUp(
+								KeyEvent.KEYCODE_DPAD_LEFT, event);
+					}
+
+					public void swipeRight() {
+						long eventTime = System.currentTimeMillis();
+						lastSwipe = eventTime;
+
+						KeyEvent event = new KeyEvent(eventTime, eventTime,
+								KeyEvent.ACTION_DOWN,
+								KeyEvent.KEYCODE_DPAD_RIGHT, 0, 0, 0, 0,
+								KeyEvent.FLAG_SOFT_KEYBOARD
+										| KeyEvent.FLAG_KEEP_TOUCH_MODE);
+						NotesActivity.this.onKeyUp(
+								KeyEvent.KEYCODE_DPAD_RIGHT, event);
+					}
+
+					public void swipeUp() {
+						// TODO Auto-generated method stub
+					}
+				});
+
+
+
+		Clue c = BOARD.getClue();
+
+		boolean showCount = prefs.getBoolean("showCount", false);
+		final int curWordLen = BOARD.getCurrentWord().length;
+
+		TextView clue = (TextView) this.findViewById(R.id.clueLine);
+		if (clue != null && clue.getVisibility() != View.GONE) {
+			clue.setVisibility(View.GONE);
+			clue = (TextView) utils.onActionBarCustom(this,
+				R.layout.clue_line_only).findViewById(R.id.clueLine);
+		}
+
+		clue.setTextSize(TypedValue.COMPLEX_UNIT_SP,
+			prefs.getInt("clueSize", 12));
+
+		clue.setText("("
+			+ (BOARD.isAcross() ? "across" : "down")
+			+ ") "
+			+ c.number
+			+ ". "
+			+ c.hint
+			+ (showCount ? ("  ["
+			+ curWordLen + "]") : ""));
+
+		imageView = (ScrollingImageView) this.findViewById(R.id.miniboard);
+		this.imageView.setContextMenuListener(new ClickListener() {
+			public void onContextMenu(Point e) {
+				// TODO Auto-generated method stub
+			}
+
+			public void onTap(Point e) {
+				imageView.requestFocus();
+
+				Word current = BOARD.getCurrentWord();
+				int newAcross = current.start.across;
+				int newDown = current.start.down;
+				int box = RENDERER.findBoxNoScale(e);
+
+				if (box < current.length) {
+					if (BOARD.isAcross()) {
+						newAcross += box;
+					} else {
+						newDown += box;
+					}
+				}
+
+				Position newPos = new Position(newAcross, newDown);
+
+				if (!newPos.equals(BOARD.getHighlightLetter())) {
+					BOARD.setHighlightLetter(newPos);
+					NotesActivity.this.render();
+				}
+			}
+		});
+
+		Note note = puz.getNote(c.number, BOARD.isAcross());
+		if (note != null) {
+			EditText notesBox = (EditText) this.findViewById(R.id.notesBox);
+			notesBox.setText(note.getText());
+		}
+
+		scratchView = (BoardEditText) this.findViewById(R.id.scratchMiniboard);
+		if (note != null) {
+			scratchView.setFromString(note.getSratch());
+		}
+        scratchView.setRenderer(renderer);
+		scratchView.setLength(curWordLen);
+		scratchView.setContextMenuListener(new ClickListener() {
+			public void onContextMenu(Point e) {
+				copyBoardViewToBoard(scratchView);
+			}
+
+			public void onTap(Point e) {
+				NotesActivity.this.render();
+			}
+		});
+
+		anagramSourceView = (BoardEditText) this.findViewById(R.id.anagramSource);
+		if (note != null) {
+			String src = note.getAnagramSource();
+			if (src != null) {
+				anagramSourceView.setFromString(src);
+				for (int i = 0; i < src.length(); i++) {
+					if (Character.isLetter(src.charAt(i))) {
+						numAnagramLetters++;
+					}
+				}
+			}
+		}
+
+		anagramSolView = (BoardEditText) this.findViewById(R.id.anagramSolution);
+		if (note != null) {
+			String sol = note.getAnagramSolution();
+			if (sol != null) {
+				anagramSolView.setFromString(sol);
+				for (int i = 0; i < sol.length(); i++) {
+					if (Character.isLetter(sol.charAt(i))) {
+						numAnagramLetters++;
+					}
+				}
+			}
+		}
+
+		BoardEditFilter sourceFilter = new BoardEditFilter() {
+			public boolean delete(char oldChar, int pos) {
+				if (Character.isLetter(oldChar)) {
+					numAnagramLetters--;
+				}
+				return true;
+			}
+
+			public char filter(char oldChar, char newChar, int pos) {
+				if (Character.isLetter(newChar)) {
+					if (Character.isLetter(oldChar)) {
+						return newChar;
+					} else if (numAnagramLetters < curWordLen) {
+						numAnagramLetters++;
+						return newChar;
+					} else {
+						return '\0';
+					}
+				} else {
+					return '\0';
+				}
+			}
+		};
+
+        anagramSourceView.setRenderer(renderer);
+		anagramSourceView.setLength(curWordLen);
+		anagramSourceView.setFilters(new BoardEditFilter[]{sourceFilter});
+		anagramSourceView.setContextMenuListener(new ClickListener() {
+			public void onContextMenu(Point e) {
+				// reshuffle squares
+				int len = anagramSourceView.getLength();
+				for (int i = 0; i < len; i++) {
+					int j = rand.nextInt(len);
+					char ci = anagramSourceView.getResponse(i);
+					char cj = anagramSourceView.getResponse(j);
+					anagramSourceView.setResponse(i, cj);
+					anagramSourceView.setResponse(j, ci);
+				}
+				NotesActivity.this.render();
+			}
+
+			public void onTap(Point e) {
+				NotesActivity.this.render();
+			}
+		});
+
+		BoardEditFilter solFilter = new BoardEditFilter() {
+			public boolean delete(char oldChar, int pos) {
+				if (Character.isLetter(oldChar)) {
+					for (int i = 0; i < curWordLen; i++) {
+						if (anagramSourceView.getResponse(i) == ' ') {
+							anagramSourceView.setResponse(i, oldChar);
+							return true;
+						}
+					}
+				}
+				return true;
+			}
+
+			public char filter(char oldChar, char newChar, int pos) {
+				if (Character.isLetter(newChar)) {
+					for (int i = 0; i < curWordLen; i++) {
+						if (anagramSourceView.getResponse(i) == newChar) {
+							anagramSourceView.setResponse(i, oldChar);
+							return newChar;
+						}
+					}
+					// if failed to find it in the source view, see if we can
+					// find one to swap it with one in the solution
+					for (int i = 0; i < curWordLen; i++) {
+						if (anagramSolView.getResponse(i) == newChar) {
+							anagramSolView.setResponse(i, oldChar);
+							return newChar;
+						}
+					}
+				}
+				return '\0';
+			}
+		};
+
+        anagramSolView.setRenderer(renderer);
+		anagramSolView.setLength(curWordLen);
+		anagramSolView.setFilters(new BoardEditFilter[]{solFilter});
+		anagramSolView.setContextMenuListener(new ClickListener() {
+			public void onContextMenu(Point e) {
+				copyBoardViewToBoard(anagramSolView);
+			}
+
+			public void onTap(Point e) {
+				NotesActivity.this.render();
+			}
+		});
+
+
+		// if not using native keyboard, hide shortyz' when the notesBox is in
+		// focus
+		OnFocusChangeListener hideKbdListener = new OnFocusChangeListener() {
+			@Override
+			public void onFocusChange(View v, boolean gainFocus) {
+				if (!NotesActivity.this.useNativeKeyboard) {
+					if (gainFocus) {
+						NotesActivity.this.keyboardView.setVisibility(View.GONE);
+					} else {
+						NotesActivity.this.keyboardView.setVisibility(View.VISIBLE);
+					}
+				}
+				if (!gainFocus) {
+					InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+					imm.hideSoftInputFromWindow(v.getWindowToken(), 0);
+				}
+			}
+		};
+
+		EditText notesBox = (EditText) this.findViewById(R.id.notesBox);
+		notesBox.setOnFocusChangeListener(hideKbdListener);
+
+		this.render();
+	}
+
+	public void onPause() {
+		super.onPause();
+
+		EditText notesBox = (EditText) this.findViewById(R.id.notesBox);
+		String text = notesBox.getText().toString();
+
+		String scratch = scratchView.toString();
+		String anagramSource = anagramSourceView.toString();
+		String anagramSolution = anagramSolView.toString();
+
+		Note note = new Note(scratch, text, anagramSource, anagramSolution);
+
+		Clue c = BOARD.getClue();
+		puz.setNote(note, c.number, BOARD.isAcross());
+
+		if (this.prefs.getBoolean("forceKeyboard", false)
+				|| (this.configuration.hardKeyboardHidden == Configuration.HARDKEYBOARDHIDDEN_YES)
+				|| (this.configuration.hardKeyboardHidden == Configuration.HARDKEYBOARDHIDDEN_UNDEFINED)) {
+			InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+			imm.hideSoftInputFromWindow(this.imageView.getWindowToken(), 0);
+			imm.hideSoftInputFromWindow(this.scratchView.getWindowToken(), 0);
+			imm.hideSoftInputFromWindow(this.anagramSourceView.getWindowToken(), 0);
+			imm.hideSoftInputFromWindow(this.anagramSolView.getWindowToken(), 0);
+		}
+	}
+
+	@Override
+	public boolean onKeyUp(int keyCode, KeyEvent event) {
+		if (keyCode == KeyEvent.KEYCODE_BACK) {
+			this.finish();
+			return true;
+		}
+
+		View focused = getWindow().getCurrentFocus();
+
+		switch (focused.getId()) {
+		case R.id.miniboard:
+			return onMiniboardKeyUp(keyCode, event);
+
+		case R.id.scratchMiniboard:
+			return scratchView.onKeyUp(keyCode, event);
+
+		case R.id.anagramSource:
+			return anagramSourceView.onKeyUp(keyCode, event);
+
+		case R.id.anagramSolution:
+			return anagramSolView.onKeyUp(keyCode, event);
+
+		default:
+			return false;
+		}
+	}
+
+	private boolean onMiniboardKeyUp(int keyCode, KeyEvent event) {
+		Word w = BOARD.getCurrentWord();
+		Position last = new Position(w.start.across
+				+ (w.across ? (w.length - 1) : 0), w.start.down
+				+ ((!w.across) ? (w.length - 1) : 0));
+
+		switch (keyCode) {
+		case KeyEvent.KEYCODE_MENU:
+			return false;
+
+		case KeyEvent.KEYCODE_DPAD_LEFT:
+
+			if (!BOARD.getHighlightLetter().equals(
+					BOARD.getCurrentWord().start)) {
+				BOARD.previousLetter();
+
+				this.render();
+			}
+
+			return true;
+
+		case KeyEvent.KEYCODE_DPAD_RIGHT:
+
+			if (!BOARD.getHighlightLetter().equals(last)) {
+				BOARD.nextLetter();
+				this.render();
+			}
+
+			return true;
+
+		case KeyEvent.KEYCODE_DEL:
+			w = BOARD.getCurrentWord();
+			BOARD.deleteLetter();
+
+			Position p = BOARD.getHighlightLetter();
+
+			if (!w.checkInWord(p.across, p.down)) {
+				BOARD.setHighlightLetter(w.start);
+			}
+
+			this.render();
+
+			return true;
+
+		case KeyEvent.KEYCODE_SPACE:
+
+			if (!prefs.getBoolean("spaceChangesDirection", true)) {
+				BOARD.playLetter(' ');
+
+				Position curr = BOARD.getHighlightLetter();
+
+				if (!BOARD.getCurrentWord().equals(w)
+						|| (BOARD.getBoxes()[curr.across][curr.down] == null)) {
+					BOARD.setHighlightLetter(last);
+				}
+
+				this.render();
+
+				return true;
+			}
+		}
+
+		char c = Character
+				.toUpperCase(((this.configuration.hardKeyboardHidden == Configuration.HARDKEYBOARDHIDDEN_NO) || this.useNativeKeyboard) ? event
+						.getDisplayLabel() : ((char) keyCode));
+
+		if (PlayActivity.ALPHA.indexOf(c) != -1) {
+			BOARD.playLetter(c);
+
+			Position p = BOARD.getHighlightLetter();
+
+			if (!BOARD.getCurrentWord().equals(w)
+					|| (BOARD.getBoxes()[p.across][p.down] == null)) {
+				BOARD.setHighlightLetter(last);
+			}
+
+			this.render();
+
+			afterPlay();
+
+			return true;
+		}
+
+		return super.onKeyUp(keyCode, event);
+	}
+
+	private void afterPlay() {
+		if ((puz.getPercentComplete() == 100) && (timer != null)) {
+			timer.stop();
+			puz.setTime(timer.getElapsed());
+			this.timer = null;
+			Intent i = new Intent(NotesActivity.this, PuzzleFinishedActivity.class);
+			this.startActivity(i);
+		}
+	}
+
+	protected void render() {
+		if (this.prefs.getBoolean("forceKeyboard", false)
+				|| (this.configuration.hardKeyboardHidden == Configuration.HARDKEYBOARDHIDDEN_YES)
+				|| (this.configuration.hardKeyboardHidden == Configuration.HARDKEYBOARDHIDDEN_UNDEFINED)) {
+			if (this.useNativeKeyboard) {
+				InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+
+				imm.toggleSoftInput(InputMethodManager.SHOW_FORCED,
+						InputMethodManager.HIDE_IMPLICIT_ONLY);
+			} else {
+				this.keyboardView.setVisibility(View.VISIBLE);
+			}
+		} else {
+			this.keyboardView.setVisibility(View.GONE);
+		}
+
+		this.imageView.setBitmap(renderer.drawWord());
+	}
+
+	private void copyBoardViewToBoard(final BoardEditText view) {
+		final Box[] curWordBoxes = BOARD.getCurrentWordBoxes();
+		boolean conflicts = false;
+
+		for (int i = 0; i < curWordBoxes.length; i++) {
+			char oldResponse = curWordBoxes[i].getResponse();
+			if (Character.isLetter(oldResponse) &&
+				view.getResponse(i) != oldResponse) {
+
+				conflicts = true;
+				break;
+			}
+		}
+
+		if (conflicts) {
+			AlertDialog.Builder builder = new AlertDialog.Builder(this);
+
+			builder.setTitle("Copy Conflict");
+			builder.setMessage("The new solution conflicts with existing entries.  Overwrite anyway?");
+			builder.setPositiveButton("YES", new DialogInterface.OnClickListener() {
+				@Override
+				public void onClick(DialogInterface dialog, int which) {
+					copyBoardViewToBoardUnchecked(view, curWordBoxes);
+					dialog.dismiss();
+				}
+			});
+			builder.setNegativeButton("NO", new DialogInterface.OnClickListener() {
+				@Override
+				public void onClick(DialogInterface dialog, int which) {
+					dialog.dismiss();
+				}
+			});
+
+			AlertDialog alert = builder.create();
+			alert.show();
+		} else {
+			copyBoardViewToBoardUnchecked(view, curWordBoxes);
+		}
+	}
+
+	private void copyBoardViewToBoardUnchecked(BoardEditText view,
+											   Box[] curWordBoxes) {
+		for (int i = 0; i < curWordBoxes.length; i++) {
+			curWordBoxes[i].setResponse(view.getResponse(i));
+		}
+
+		render();
+		afterPlay();
+	}
+}

--- a/app/src/main/java/com/totsp/crossword/PlayActivity.java
+++ b/app/src/main/java/com/totsp/crossword/PlayActivity.java
@@ -714,6 +714,7 @@ public class PlayActivity extends ShortyzActivity {
         }
 
         menu.add("Clues").setIcon(android.R.drawable.ic_menu_agenda);
+        menu.add("Notes").setIcon(android.R.drawable.ic_menu_agenda);
         Menu clueSize = menu.addSubMenu("Clue Text Size");
         clueSize.add(createSpannableForMenu("Small")).setTitleCondensed("Small");
         clueSize.add(createSpannableForMenu("Medium")).setTitleCondensed("Medium");
@@ -989,6 +990,10 @@ public class PlayActivity extends ShortyzActivity {
             i.setData(Uri.fromFile(baseFile));
             PlayActivity.this.startActivityForResult(i, 0);
 
+            return true;
+        } else if (item.getTitle().toString().equals("Notes")) {
+            Intent i = new Intent(PlayActivity.this, NotesActivity.class);
+            PlayActivity.this.startActivityForResult(i, 0);
             return true;
         } else if (item.getTitle().toString().equals("Help")) {
             Intent i = new Intent(Intent.ACTION_VIEW,

--- a/app/src/main/java/com/totsp/crossword/view/BoardEditText.java
+++ b/app/src/main/java/com/totsp/crossword/view/BoardEditText.java
@@ -1,0 +1,308 @@
+package com.totsp.crossword.view;
+
+import static com.totsp.crossword.shortyz.ShortyzApplication.RENDERER;
+import static com.totsp.crossword.shortyz.ShortyzApplication.BOARD;
+
+import java.lang.StringBuilder;
+
+import android.preference.PreferenceManager;
+import android.content.SharedPreferences;
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.KeyEvent;
+import android.view.View;
+import android.content.res.Configuration;
+import java.util.logging.Logger;
+
+import com.totsp.crossword.puz.Playboard.Position;
+import com.totsp.crossword.view.PlayboardRenderer;
+import com.totsp.crossword.puz.Box;
+import com.totsp.crossword.PlayActivity;
+
+public class BoardEditText extends ScrollingImageView {
+    private static final Logger LOG = Logger.getLogger(BoardEditText.class.getCanonicalName());
+
+    public interface BoardEditFilter {
+        /**
+         * @param oldChar the character being deleted
+         * @param pos the position of the box being deleted from
+         * @return true if the deletion is allowed to occur
+         */
+        public boolean delete(char oldChar, int pos);
+
+        /**
+         * @param oldChar the character that used to be in the box
+         * @param newChar the character to replace it with
+         * @param pos the position of the box
+         * @return the actual character to replace the old one with or null char
+         * if the replacement is not allowed
+         */
+        public char filter(char oldChar, char newChar, int pos);
+    }
+
+    private Position selection = new Position(-1, 0);
+    private Box[] boxes;
+    private PlayboardRenderer renderer = RENDERER;
+    // surely a better way...
+    static final String ALPHA = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    private boolean useNativeKeyboard = false;
+    private Configuration configuration;
+
+    // we have our own onTap for input, but the activity containing the widget
+    // might also need to know about on taps, so override setContextMenuListener
+    // to intercept
+    private ClickListener ctxListener;
+    private BoardEditFilter[] filters;
+
+    /**
+     * Call setRenderer to set the same renderer as used by the activity using
+     * the boardedittext widget.  Else, falls back onto
+     * ShortyzApplication.RENDERER
+     */
+    public BoardEditText(Context context, AttributeSet as) {
+        super(context, as);
+
+        super.setContextMenuListener(new ClickListener() {
+            public void onContextMenu(Point e) {
+                if (ctxListener != null) {
+                    ctxListener.onContextMenu(e);
+                }
+            }
+
+            public void onTap(Point e) {
+                BoardEditText.this.requestFocus();
+
+                int box = RENDERER.findBoxNoScale(e);
+                if (boxes != null && box < boxes.length) {
+                    selection.across = box;
+                }
+                BoardEditText.this.render();
+
+                if (ctxListener != null) {
+                    ctxListener.onTap(e);
+                }
+            }
+        });
+
+        setOnFocusChangeListener(new OnFocusChangeListener() {
+            @Override
+            public void onFocusChange(View v, boolean gainFocus) {
+                if (!gainFocus) {
+                    selection.across = -1;
+                    BoardEditText.this.render();
+                } else if (boxes != null &&
+                           (selection.across < 0 ||
+                            selection.across >= boxes.length)) {
+                    selection.across = 0;
+                    BoardEditText.this.render();
+                }
+            }
+        });
+
+        SharedPreferences prefs
+            = PreferenceManager.getDefaultSharedPreferences(context);
+        useNativeKeyboard = "NATIVE".equals(prefs.getString("keyboardType", ""));
+
+        configuration = context.getResources().getConfiguration();
+    }
+
+    @Override
+    public void setContextMenuListener(ClickListener l) {
+        this.ctxListener = l;
+    }
+
+    public void setFilters(BoardEditFilter[] filters) {
+        this.filters = filters;
+    }
+
+    public void setLength(int len) {
+        if (boxes == null || len != boxes.length) {
+            Box[] newBoxes = new Box[len];
+
+            int overlap = 0;
+            if (boxes != null) {
+                overlap = Math.min(len, boxes.length);
+                for (int i = 0; i < overlap; i++) {
+                    newBoxes[i] = boxes[i];
+                }
+            }
+
+            for (int i = overlap; i < len; ++i) {
+                newBoxes[i] = new Box();
+            }
+
+            boxes = newBoxes;
+
+            render();
+        }
+    }
+
+    public void setRenderer(PlayboardRenderer renderer) {
+        this.renderer = renderer;
+        render();
+    }
+
+    public int getLength() {
+        return (boxes == null) ? 0 : boxes.length;
+    }
+
+    public char getResponse(int pos) {
+        if (boxes != null && 0 <= pos && pos < boxes.length) {
+            return boxes[pos].getResponse();
+        } else {
+            return '\0';
+        }
+    }
+
+    public void setResponse(int pos, char c) {
+        if (boxes != null && 0 <= pos && pos < boxes.length) {
+            boxes[pos].setResponse(c);
+            render();
+        }
+    }
+
+    public void setFromString(String text) {
+        if (text == null) {
+            boxes = null;
+        } else {
+            boxes = new Box[text.length()];
+            for (int i = 0; i < text.length(); i++) {
+                boxes[i] = new Box();
+                boxes[i].setResponse(text.charAt(i));
+            }
+        }
+        render();
+    }
+
+    public String toString() {
+        if (boxes == null) {
+            return "";
+        }
+
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < boxes.length; i++) {
+            sb.append(boxes[i].getResponse());
+        }
+
+        return sb.toString();
+    }
+
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+		switch (keyCode) {
+		case KeyEvent.KEYCODE_MENU:
+			return false;
+
+        case KeyEvent.KEYCODE_DPAD_LEFT:
+			if (selection.across > 0) {
+				selection.across--;
+				this.render();
+			}
+			return true;
+
+		case KeyEvent.KEYCODE_DPAD_RIGHT:
+			if (boxes != null && selection.across < boxes.length - 1) {
+				selection.across++;
+				this.render();
+			}
+
+			return true;
+
+		case KeyEvent.KEYCODE_DEL:
+            if (boxes != null && canDelete(selection)) {
+                boxes[selection.across].setResponse(' ');
+                if (selection.across > 0) {
+                    selection.across--;
+                }
+                this.render();
+            }
+            return true;
+
+		case KeyEvent.KEYCODE_SPACE:
+            if (boxes != null && canDelete(selection)) {
+                boxes[selection.across].setResponse(' ');
+
+                if (selection.across < boxes.length - 1) {
+                    selection.across++;
+                }
+
+                this.render();
+            }
+            return true;
+        }
+
+		char c = Character
+				.toUpperCase(((this.configuration.hardKeyboardHidden == Configuration.HARDKEYBOARDHIDDEN_NO) || this.useNativeKeyboard) ? event
+						.getDisplayLabel() : ((char) keyCode));
+
+		if (boxes != null && ALPHA.indexOf(c) != -1) {
+            c = filterReplacement(c, selection);
+
+            if (c != '\0') {
+                boxes[selection.across].setResponse(c);
+
+                if (selection.across < boxes.length - 1) {
+                    selection.across++;
+
+                    int nextPos = selection.across;
+
+                    while (BOARD.isSkipCompletedLetters() &&
+                           boxes[selection.across].getResponse() != ' ' &&
+                           selection.across < boxes.length - 1) {
+                        selection.across++;
+                    }
+
+                    if (boxes[selection.across].getResponse() != ' ')
+                        selection.across = nextPos;
+                }
+
+                this.render();
+            }
+
+            return true;
+		}
+
+		return super.onKeyUp(keyCode, event);
+	}
+
+    private void render() {
+        setBitmap(renderer.drawBoxes(boxes, selection));
+    }
+
+    private boolean canDelete(Position pos) {
+        if (filters == null)
+            return true;
+
+        if (boxes == null || pos.across < 0 || pos.across >= boxes.length)
+            return false;
+
+        char oldChar = boxes[pos.across].getResponse();
+
+        for (BoardEditFilter filter : filters) {
+            if (filter != null && !filter.delete(oldChar, pos.across)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private char filterReplacement(char newChar, Position pos) {
+        if (filters == null)
+            return newChar;
+
+        if (boxes == null || pos.across < 0 || pos.across >= boxes.length)
+            return '\0';
+
+        char oldChar = boxes[pos.across].getResponse();
+
+        for (BoardEditFilter filter : filters) {
+            if (filter != null) {
+                newChar = filter.filter(oldChar, newChar, pos.across);
+            }
+        }
+
+        return newChar;
+    }
+}

--- a/app/src/main/java/com/totsp/crossword/view/PlayboardRenderer.java
+++ b/app/src/main/java/com/totsp/crossword/view/PlayboardRenderer.java
@@ -169,7 +169,7 @@ public class PlayboardRenderer {
 
                     int x = col * boxSize;
                     int y = row * boxSize;
-                    this.drawBox(canvas, x, y, row, col, boxSize, boxes[col][row], currentWord);
+                    this.drawBox(canvas, x, y, row, col, boxSize, boxes[col][row], currentWord, this.board.getHighlightLetter());
                 }
             }
 
@@ -191,11 +191,40 @@ public class PlayboardRenderer {
         for (int i = 0; i < word.length; i++) {
             int x = i * boxSize;
             int y = 0;
-            this.drawBox(canvas, x, y, word[i].down, word[i].across, boxSize, boxes[i], null);
+            this.drawBox(canvas, x, y, word[i].down, word[i].across, boxSize, boxes[i], null, this.board.getHighlightLetter());
         }
 
         return bitmap;
     }
+
+    public Bitmap drawBoxes(Box[] boxes, Position highlight) {
+        if (boxes == null || boxes.length == 0) {
+            return null;
+        }
+
+        int boxSize = (int) (BASE_BOX_SIZE_INCHES * this.dpi * scale);
+        Bitmap bitmap = Bitmap.createBitmap((int) (boxes.length * boxSize),
+                                            (int) (boxSize),
+                                            Bitmap.Config.RGB_565);
+        bitmap.eraseColor(Color.BLACK);
+
+        Canvas canvas = new Canvas(bitmap);
+
+        for (int i = 0; i < boxes.length; i++) {
+            int x = (int) (i * boxSize);
+            int y = 0;
+            this.drawBox(canvas,
+                         x, y,
+                         0, i,
+                         boxSize,
+                         boxes[i],
+                         null,
+                         highlight);
+        }
+
+        return bitmap;
+    }
+
 
     public Position findBox(Point p) {
         int boxSize = (int) (BASE_BOX_SIZE_INCHES * dpi * scale);
@@ -277,7 +306,7 @@ public class PlayboardRenderer {
         return scale;
     }
 
-    private void drawBox(Canvas canvas, int x, int y, int row, int col, int boxSize, Box box, Word currentWord) {
+    private void drawBox(Canvas canvas, int x, int y, int row, int col, int boxSize, Box box, Word currentWord, Position highlight) {
         int numberTextSize = boxSize / 4;
         int letterTextSize = Math.round(boxSize * 0.7F);
 
@@ -288,7 +317,6 @@ public class PlayboardRenderer {
         white.setTextSize(letterTextSize);
 
         boolean inCurrentWord = (currentWord != null) && currentWord.checkInWord(col, row);
-        Position highlight = this.board.getHighlightLetter();
 
         Paint thisLetter;
 

--- a/app/src/main/res/layout/notes.xml
+++ b/app/src/main/res/layout/notes.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:orientation="vertical" >
+
+    <TextView
+        android:id="@+id/clueLine"
+		android:layout_width="fill_parent"
+		android:layout_height="wrap_content"
+		android:textSize="12dip"
+		android:minLines="2"
+		android:maxLines="4"
+		android:textColor="#FFFFFF"
+		android:background="#2C2C2C"
+	/>
+
+    <TextView
+        android:id="@+id/boardLab"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/board_lab"
+        android:layout_below="@+id/clueLine"
+    />
+
+    <com.totsp.crossword.view.ScrollingImageView
+        android:id="@+id/miniboard"
+        android:layout_width="fill_parent"
+        android:layout_height="0.3in"
+        android:layout_below="@+id/boardLab"
+        android:focusable="true"
+        android:focusableInTouchMode="true" >
+        <requestFocus />
+    </com.totsp.crossword.view.ScrollingImageView>
+
+
+    <ScrollView
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:layout_below="@+id/miniboard"
+        android:layout_above="@+id/notesKeyboard"
+        android:fillViewport="true" >
+
+        <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:orientation="vertical" >
+
+            <TextView
+                android:id="@+id/scratchLab"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/scratch_lab"
+                android:inputType="text"
+            />
+
+            <com.totsp.crossword.view.BoardEditText
+                android:id="@+id/scratchMiniboard"
+                android:layout_width="fill_parent"
+                android:layout_height="0.3in"
+                android:layout_below="@+id/scratchLab"
+                android:focusable="true"
+                android:focusableInTouchMode="true"
+            />
+
+            <TextView
+                android:id="@+id/notesLab"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/notes_lab"
+            />
+
+            <EditText
+                android:id="@+id/notesBox"
+                android:layout_width="fill_parent"
+                android:layout_height="0dip"
+                android:layout_weight="1.0"
+                android:gravity="top"
+                android:typeface="monospace"
+            />
+
+            <TextView
+                android:id="@+id/anagramSourceLab"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/anagram_source_lab"
+                android:layout_below="@+id/notesBox"
+            />
+
+            <com.totsp.crossword.view.BoardEditText
+                android:id="@+id/anagramSource"
+                android:layout_width="fill_parent"
+                android:layout_below="@+id/anagramSourceLab"
+                android:layout_height="0.3in"
+                android:focusable="true"
+                android:focusableInTouchMode="true"
+            />
+
+            <TextView
+                android:id="@+id/anagramSolutionLab"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/anagram_solution_lab"
+                android:layout_below="@+id/notesBox"
+            />
+
+            <com.totsp.crossword.view.BoardEditText
+                android:id="@+id/anagramSolution"
+                android:layout_width="fill_parent"
+                android:layout_below="@+id/anagramSolutionLab"
+                android:layout_height="0.3in"
+                android:focusable="true"
+                android:focusableInTouchMode="true"
+            />
+
+        </LinearLayout>
+    </ScrollView>
+
+    <android.inputmethodservice.KeyboardView
+        android:id="@+id/notesKeyboard"
+        android:layout_alignParentBottom="true"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:keyBackground="@color/transparent"
+        android:keyTextColor="@color/textColorPrimary"
+        android:background="@color/background_material_light"
+        android:shadowRadius="0.0"
+        android:keyPreviewLayout="@layout/key_preview"
+        />
+
+
+</RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,9 @@
     <string name="done_button">Done</string>
     <string name="across">Across</string>
     <string name="down">Down</string>
+    <string name="anagram_source_lab">Anagram remaining letters:</string>
+    <string name="anagram_solution_lab">Anagram solution:</string>
+    <string name="board_lab">Board:</string>
+    <string name="scratch_lab">Scratch:</string>
+    <string name="notes_lab">Notes:</string>
 </resources>

--- a/puzlib/src/main/java/com/totsp/crossword/puz/Note.java
+++ b/puzlib/src/main/java/com/totsp/crossword/puz/Note.java
@@ -1,0 +1,96 @@
+package com.totsp.crossword.puz;
+
+import java.io.Serializable;
+
+public class Note implements Serializable {
+    private String scratch;
+    private String text;
+    private String anagramSource;
+    private String anagramSolution;
+
+    public Note(String scratch,
+                String text,
+                String anagramSource,
+                String anagramSolution) {
+        this.text = text;
+        this.scratch = scratch;
+        this.anagramSource = anagramSource;
+        this.anagramSolution = anagramSolution;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public String getSratch() {
+        return scratch;
+    }
+
+    public String getAnagramSource() {
+        return anagramSource;
+    }
+
+    public String getAnagramSolution() {
+        return anagramSolution;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public void setScratch(String scratch) {
+        this.scratch = scratch;
+    }
+
+    public void setAnagramSource(String anagramSource) {
+        this.anagramSource = anagramSource;
+    }
+
+    public void setAnagramSolution(String anagramSolution) {
+        this.anagramSolution = anagramSolution;
+    }
+
+    public boolean isEmpty() {
+        return (text == null || text.length() == 0) &&
+               (scratch == null || scratch.trim().length() == 0) &&
+               (anagramSource == null || anagramSource.trim().length() == 0) &&
+               (anagramSolution == null || anagramSolution.trim().length() == 0);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof Note) {
+            Note n = (Note) o;
+            return safeStringEquals(this.text, n.text) &&
+                   safeStringEquals(this.scratch, n.scratch) &&
+                   safeStringEquals(this.anagramSource, n.anagramSource) &&
+                   safeStringEquals(this.anagramSolution, n.anagramSolution);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+
+        result = (prime * result) + (text == null ? 0 : text.hashCode());
+        result = (prime * result) +
+                 (scratch == null ? 0 : scratch.hashCode());
+        result = (prime * result) +
+                 (anagramSource == null ? 0 : anagramSource.hashCode());
+        result = (prime * result) +
+                 (anagramSolution == null ? 0 : anagramSolution.hashCode());
+
+        return result;
+    }
+
+
+    private static final boolean safeStringEquals(String s1, String s2) {
+        if (s1 == null) {
+            return (s2 == null);
+        } else {
+            return s1.equals(s2);
+        }
+    }
+}

--- a/puzlib/src/main/java/com/totsp/crossword/puz/Puzzle.java
+++ b/puzlib/src/main/java/com/totsp/crossword/puz/Puzzle.java
@@ -33,7 +33,10 @@ public class Puzzle implements Serializable{
     private boolean hasGEXT;
     private Position position;
     private boolean across = true;
-    
+
+    private Note[] acrossNotes = null;
+    private Note[] downNotes = null;;
+
     // Temporary fields used for unscrambling.
     public int[] unscrambleKey;
     public byte[] unscrambleTmp;
@@ -142,7 +145,7 @@ public class Puzzle implements Serializable{
 
         return result;
     }
-    
+
     /**
      * Initialize the temporary unscramble buffers.  Returns the scrambled solution.
      */
@@ -410,6 +413,68 @@ public class Puzzle implements Serializable{
         return boxes;
     }
 
+    public Note[] getAcrossNotes() {
+        return acrossNotes;
+    }
+
+    public Note[] getDownNotes() {
+        return downNotes;
+    }
+
+    public Note getNote(int clueNum, boolean isAcross) {
+        if (isAcross && acrossNotes == null)
+            return null;
+        else if (!isAcross && downNotes == null)
+            return null;
+
+        if (isAcross) {
+            int idx = Arrays.binarySearch(acrossCluesLookup, clueNum);
+            return (idx < 0) ? null : acrossNotes[idx];
+        } else {
+            int idx = Arrays.binarySearch(downCluesLookup, clueNum);
+            return (idx < 0) ? null : downNotes[idx];
+        }
+    }
+
+    /**
+     * Assumes acrossClues and downClues has been initialised
+     */
+    public void setNote(Note note, int clueNum, boolean isAcross) {
+        if (note == null || note.isEmpty()) {
+            return;
+        }
+
+        int idx = isAcross ? Arrays.binarySearch(acrossCluesLookup, clueNum)
+                           : Arrays.binarySearch(downCluesLookup, clueNum);
+
+        setNoteRaw(note, idx, isAcross);
+    }
+
+    /**
+     * Assumes acrossClues and downClues has been initialised
+     */
+    public void setNoteRaw(Note note, int clueIdx, boolean isAcross) {
+        if (note == null || note.isEmpty()) {
+            return;
+        }
+
+        if (isAcross) {
+            if (clueIdx >= 0 && clueIdx <= acrossClues.length) {
+                if (acrossNotes == null) {
+                    acrossNotes = new Note[acrossClues.length];
+                }
+                acrossNotes[clueIdx] = note;
+            }
+        } else {
+            if (clueIdx >= 0 && clueIdx <= downClues.length) {
+                if (downNotes == null) {
+                    downNotes = new Note[downClues.length];
+                }
+                downNotes[clueIdx] = note;
+            }
+        }
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -542,6 +607,14 @@ public class Puzzle implements Serializable{
         	return false;
         }
 
+        if (!Arrays.equals(acrossNotes, other.acrossNotes)) {
+            return false;
+        }
+
+        if (!Arrays.equals(downNotes, other.downNotes)) {
+            return false;
+        }
+
         return true;
     }
 
@@ -573,6 +646,8 @@ public class Puzzle implements Serializable{
         result = (prime * result) + ((title == null) ? 0 : title.hashCode());
         result = (prime * result) + ((version == null) ? 0 : version.hashCode());
         result = (prime * result) + width;
+        result = (prime *result) + Arrays.hashCode(acrossNotes);
+        result = (prime *result) + Arrays.hashCode(downNotes);
 
         return result;
     }


### PR DESCRIPTION
Added a notes page activity where notes, partial solutions, and anagrams can be experimented with.  I find this useful for cryptic crosswords.

This includes the addition of a NotesActivity class as well as a BoardEditText widget (akin to TextEdit) to edit text in crossword style.  I have also added an options menu to the clues list activity, though the only option is to get to the notes page.

Notes are stored in the same file as the user's crossword answers in a section marked with ANTS and DNTS (across/down notes).  This is similar to GEXT and if it is not present it is assumed empty.  (Ie existing files with previous versions of Shortyz should work perfectly well.)

A smaller technical change is to the PlayboardRenderer class's drawBox method to take the selected square position (used by BoardEditText).

Future work might be to refactor NotesActivity and ClueListActivity to remove a lot of copy-pasted code to do with keyboard handling.