### PR TITLE
Create puzzle metadata when downloading NYT puzzles.

### DIFF
--- a/app/src/main/java/com/totsp/crossword/net/NYTDownloader.java
+++ b/app/src/main/java/com/totsp/crossword/net/NYTDownloader.java
@@ -4,12 +4,14 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 import android.preference.PreferenceManager;
 import android.support.v4.app.NotificationCompat;
 import android.widget.Toast;
 
 import com.totsp.crossword.io.IO;
 import com.totsp.crossword.nyt.ErrorActivity;
+import com.totsp.crossword.puz.PuzzleMeta;
 import com.totsp.crossword.shortyz.ShortyzApplication;
 
 import java.io.File;
@@ -132,6 +134,14 @@ public class NYTDownloader extends AbstractDownloader {
                         .putBoolean("didNYTLogin", true)
                         .apply();
                 File f = new File(downloadDirectory, this.createFileName(date));
+
+                PuzzleMeta meta = new PuzzleMeta();
+                meta.date = date;
+                meta.source = getName();
+                meta.sourceUrl = url.toString();
+                meta.updatable = false;
+                utils.storeMetas(Uri.fromFile(f), meta);
+                
                 FileOutputStream fos = new FileOutputStream(f);
                 IO.copyStream(
                         response.body().byteStream(), fos);


### PR DESCRIPTION
Populate and store PuzzleMeta when downloading NYT puzzles.

The current implementation does not do this which leads to incorrect puzzle titles, missing description and date in the puzzle view, and puzzles changing dates due to being sorted by file timestamp instead of the parsed date.

Fixes #117

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kebernet/shortyz/131)
<!-- Reviewable:end -->
