### PR TITLE
Download KFS crosswords in .jpz format

### DIFF
--- a/app/src/main/java/com/totsp/crossword/net/Downloaders.java
+++ b/app/src/main/java/com/totsp/crossword/net/Downloaders.java
@@ -105,19 +105,19 @@ public class Downloaders {
         }
 
         if (prefs.getBoolean("downloadJoseph", true)) {
-            downloaders.add(new KFSDownloader("joseph", "Joseph Crosswords",
-                    "Thomas Joseph", Downloader.DATE_NO_SUNDAY));
+            downloaders.add(new KFSDownloader("Joseph", "Joseph Crosswords",
+                    Downloader.DATE_NO_SUNDAY));
         }
 
         if (prefs.getBoolean("downloadSheffer", true)) {
-            downloaders.add(new KFSDownloader("sheffer", "Sheffer Crosswords",
-                    "Eugene Sheffer", Downloader.DATE_NO_SUNDAY));
+            downloaders.add(new KFSDownloader("Sheffer", "Sheffer Crosswords",
+                    Downloader.DATE_NO_SUNDAY));
         }
 
-//        if (prefs.getBoolean("downloadPremier", true)) {
-//            downloaders.add(new KFSDownloader("premier", "Premier Crosswords",
-//                    "Frank Longo", Downloader.DATE_SUNDAY));
-//        }
+        if (prefs.getBoolean("downloadPremier", true)) {
+            downloaders.add(new KFSDownloader("Premier", "Premier Crosswords",
+                    Downloader.DATE_SUNDAY));
+        }
 
         if (prefs.getBoolean("downloadNewsday", true)) {
             downloaders.add(new BrainsOnlyDownloader(

--- a/app/src/main/java/com/totsp/crossword/net/KFSDownloader.java
+++ b/app/src/main/java/com/totsp/crossword/net/KFSDownloader.java
@@ -1,42 +1,25 @@
 package com.totsp.crossword.net;
 
-import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.text.DateFormat;
-import java.text.NumberFormat;
+import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.logging.Level;
-
-import com.totsp.crossword.io.KingFeaturesPlaintextIO;
-import com.totsp.crossword.versions.DefaultUtil;
-
 
 /**
  * King Features Syndicate Puzzles
- * URL: http://[puzzle].king-online.com/clues/YYYYMMDD.txt
+ * URL: http://puzzles.kingdigital.com/jpz/YYYYMMDD.jpz
  * premier = Sunday
  * joseph = Monday-Saturday
  * sheffer = Monday-Saturday
  */
-public class KFSDownloader extends AbstractDownloader {
-    DateFormat df = DateFormat.getDateInstance(DateFormat.MEDIUM);
-    NumberFormat nf = NumberFormat.getInstance();
-    private String author;
+public class KFSDownloader extends AbstractJPZDownloader {
+    SimpleDateFormat df = new SimpleDateFormat("yyyyMMdd");
     private String fullName;
     private int[] days;
 
-    public KFSDownloader(String shortName, String fullName, String author, int[] days) {
-        super("http://puzzles.kingdigital.com/javacontent/clues/"+shortName+"/", DOWNLOAD_DIR, fullName);
+    public KFSDownloader(String shortName, String fullName, int[] days) {
+        super("http://puzzles.kingdigital.com/jpz/"+shortName+"/", DOWNLOAD_DIR, fullName);
         this.fullName = fullName;
-        this.author = author;
         this.days = days;
-        nf.setMinimumIntegerDigits(2);
-        nf.setMaximumFractionDigits(0);
     }
 
     public int[] getDownloadDates() {
@@ -48,47 +31,11 @@ public class KFSDownloader extends AbstractDownloader {
     }
 
     public File download(Date date) {
-        File downloadTo = new File(this.downloadDirectory, this.createFileName(date));
-
-        if (downloadTo.exists()) {
-            return null;
-        }
-
-        File plainText = downloadToTempFile(this.getName(), date);
-
-        if (plainText == null) {
-            return null;
-        }
-
-        String copyright = "\u00a9 " + (date.getYear() + 1900) + " King Features Syndicate.";
-
-        try {
-            InputStream is = new FileInputStream(plainText);
-            DataOutputStream os = new DataOutputStream(new FileOutputStream(downloadTo));
-            boolean retVal = KingFeaturesPlaintextIO.convertKFPuzzle(is, os, fullName + ", " + df.format(date), author,
-                    copyright, date);
-            os.close();
-            is.close();
-            plainText.delete();
-
-            if (!retVal) {
-                LOG.log(Level.SEVERE, "Unable to convert KFS puzzle into Across Lite format.");
-                downloadTo.delete();
-                downloadTo = null;
-            }
-        } catch (Exception ioe) {
-            LOG.log(Level.SEVERE, "Exception converting KFS puzzle into Across Lite format.", ioe);
-            downloadTo.delete();
-            downloadTo = null;
-        }
-
-        return downloadTo;
+        return download(date, this.createUrlSuffix(date), EMPTY_MAP);
     }
 
     @Override
     protected String createUrlSuffix(Date date) {
-        return (date.getYear() + 1900) + nf.format(date.getMonth() + 1) + nf.format(date.getDate()) + ".txt";
+        return df.format(date) + ".jpz";
     }
-
-
 }


### PR DESCRIPTION
Plaintext versions of KFS puzzles are no longer available, download in .jpz format.

Fixes #144 