### PR TITLE
Fix performance of SeparatedRecyclerViewAdapter.

### DIFF
--- a/app/src/main/java/com/totsp/crossword/view/recycler/SeparatedRecyclerViewAdapter.java
+++ b/app/src/main/java/com/totsp/crossword/view/recycler/SeparatedRecyclerViewAdapter.java
@@ -26,21 +26,25 @@ public class SeparatedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
     @Override
     public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup viewGroup, int viewType) {
         if(viewType == HEADER){
+            // For headers, we can create a simple text holder.
             TextView view = (TextView) LayoutInflater.from(viewGroup.getContext())
                     .inflate(textViewId, viewGroup, false);
             return new SimpleTextViewHolder(view);
         } else {
-            RecyclerView.ViewHolder result = null;
-            while(result == null){
-                for(RecyclerView.Adapter sectionAdapter : sections.values()){
-                    try {
-                        result = sectionAdapter.onCreateViewHolder(viewGroup, viewType);
-                    } catch(Exception e){
-                        e.printStackTrace();
-                    }
+            // For puzzle views, any sectionAdapter can be used to create the view holder, so find
+            // the first one that gives us a result.
+            for(RecyclerView.Adapter sectionAdapter : sections.values()){
+                RecyclerView.ViewHolder result = null;
+                try {
+                    result = sectionAdapter.onCreateViewHolder(viewGroup, viewType);
+                } catch(Exception e){
+                    e.printStackTrace();
+                }
+                if (result != null) {
+                    return result;
                 }
             }
-            return result;
+            return null;
         }
     }
 


### PR DESCRIPTION
When creating the ViewHolder for a puzzle item, the adapter was iterating over every section in the adapter, inflating a layout, and keeping only the last one.

I believe that this causes the time required to render the main BrowseActivity to grow quadratically with the number of sections in the BrowseActivity.

For a large crossword library (several years worth) on a Pixel 2, this decreases the time to open the BrowseActivity and have a usable UI from over a minute to several seconds.  The time now seems to be dominated by time required to perform the file system operations to list the puzzles.