### PR TITLE
Add new location for Kegler's Kryptics

### DIFF
--- a/app/src/main/java/com/totsp/crossword/net/KeglerScraper.java
+++ b/app/src/main/java/com/totsp/crossword/net/KeglerScraper.java
@@ -1,9 +1,11 @@
 package com.totsp.crossword.net;
 
 
-//http://www.lafn.org/~keglerron/Block_style/index.html
+// http://www.lafn.org/~keglerron/Block_style/index.html
+// replaced by https://kegler.gitlab.io/Block_style/
+// because lafn.org is gone
 public class KeglerScraper extends AbstractPageScraper {
     public KeglerScraper() {
-        super("http://www.lafn.org/~keglerron/Block_style/index.html", "Kegler's Kryptics");
+        super("https://kegler.gitlab.io/Block_style/", "Kegler's Kryptics");
     }
 }


### PR DESCRIPTION
I discovered that Ron Sweet's site moved, but didn't actually contain any puzzles. I asked him about it, and as a result ended up building him a new site on gitlab pages, so now https://kegler.gitlab.io/ has all Kegler's Kryptics back online.

All the .puz files should now be available at the new location in this PR. Thanks!