### PR TITLE
Remove dialog during NYT login.

### DIFF
--- a/app/src/main/java/com/totsp/crossword/nyt/LoginActivity.java
+++ b/app/src/main/java/com/totsp/crossword/nyt/LoginActivity.java
@@ -1,7 +1,6 @@
 package com.totsp.crossword.nyt;
 
 import android.annotation.SuppressLint;
-import android.app.ProgressDialog;
 import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.support.design.widget.FloatingActionButton;
@@ -63,19 +62,14 @@ public class LoginActivity extends ShortyzActivity {
 
 
         webview.setWebViewClient(new WebViewClient(){
-
-            ProgressDialog dialog;
-
             @Override
             public void onPageStarted(WebView view, String url, Bitmap favicon) {
                 super.onPageStarted(view, url, favicon);
-                dialog = ProgressDialog.show(LoginActivity.this, "Please wait...", null, true);
             }
 
             @Override
             public void onPageFinished(WebView view, String url) {
                 super.onPageFinished(view, url);
-                dialog.dismiss();
                 if(url.startsWith(PUZZLES_URL)){
                     String string = CookieManager.getInstance().getCookie(url);
                     LOG.info("Got cookie string: "+string);


### PR DESCRIPTION
It seems like the login flow changed, and there is an additional URL loaded via the WebView that doesn't result in a call to onPageFinished.  This leaves the dialog up over the login page, even though it has loaded successfully.

Tested this by logging in on a fresh emulator.

I believe this may address issue #156 