### PR TITLE
Add option to change direction on arrow keys

### DIFF
--- a/app/src/main/java/com/totsp/crossword/PlayActivity.java
+++ b/app/src/main/java/com/totsp/crossword/PlayActivity.java
@@ -781,8 +781,13 @@ public class PlayActivity extends ShortyzActivity {
             case KeyEvent.KEYCODE_DPAD_DOWN:
 
                 if ((System.currentTimeMillis() - lastKey) > 50) {
-                    previous = getBoard().moveDown();
-                    this.render(previous);
+                    if (prefs.getBoolean("arrowKeysChangeDirection", false) && getBoard().isAcross()) {
+                        previous = getBoard().toggleDirection();
+                        this.render(previous);
+                    } else {
+                        previous = getBoard().moveDown();
+                        this.render(previous);
+                    }
                 }
 
 
@@ -792,8 +797,13 @@ public class PlayActivity extends ShortyzActivity {
             case KeyEvent.KEYCODE_DPAD_UP:
 
                 if ((System.currentTimeMillis() - lastKey) > 50) {
-                    previous = getBoard().moveUp();
-                    this.render(previous);
+                    if (prefs.getBoolean("arrowKeysChangeDirection", false) && getBoard().isAcross()) {
+                        previous = getBoard().toggleDirection();
+                        this.render(previous);
+                    } else {
+                        previous = getBoard().moveUp();
+                        this.render(previous);
+                    }
                 }
 
                 lastKey = System.currentTimeMillis();
@@ -803,8 +813,13 @@ public class PlayActivity extends ShortyzActivity {
             case KeyEvent.KEYCODE_DPAD_LEFT:
 
                 if ((System.currentTimeMillis() - lastKey) > 50) {
-                    previous = getBoard().moveLeft();
-                    this.render(previous);
+                    if (prefs.getBoolean("arrowKeysChangeDirection", false) && !getBoard().isAcross()) {
+                        previous = getBoard().toggleDirection();
+                        this.render(previous);
+                    } else {
+                        previous = getBoard().moveLeft();
+                        this.render(previous);
+                    }
                 }
 
                 lastKey = System.currentTimeMillis();
@@ -814,8 +829,13 @@ public class PlayActivity extends ShortyzActivity {
             case KeyEvent.KEYCODE_DPAD_RIGHT:
 
                 if ((System.currentTimeMillis() - lastKey) > 50) {
-                    previous = getBoard().moveRight();
-                    this.render(previous);
+                    if (prefs.getBoolean("arrowKeysChangeDirection", false) && !getBoard().isAcross()) {
+                        previous = getBoard().toggleDirection();
+                        this.render(previous);
+                    } else {
+                        previous = getBoard().moveRight();
+                        this.render(previous);
+                    }
                 }
 
                 lastKey = System.currentTimeMillis();

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -310,6 +310,13 @@
 		android:summary="Enter changes direction rather than moving to the next clue."
 		android:key="enterChangesDirection"
 	/>
+
+	<androidx.preference.CheckBoxPreference
+		android:title="Arrow Keys Change Direction"
+		android:defaultValue="false"
+		android:summary="Arrow keys change direction instead of moving the cursor when you try to move perpendicular to the current direction."
+		android:key="arrowKeysChangeDirection"
+	/>
 	
 	<androidx.preference.CheckBoxPreference
 		android:title="Double Tap Zoom"


### PR DESCRIPTION
This is the default behaviour on NYT Crossword app on iPad, I think it will be a useful addition as this is what I am used to. 