### PR TITLE
Movement strategy settings fix.

### DIFF
--- a/app/src/main/java/com/totsp/crossword/PlayActivity.java
+++ b/app/src/main/java/com/totsp/crossword/PlayActivity.java
@@ -1089,6 +1089,7 @@ public class PlayActivity extends ShortyzActivity {
         this.resumedOn = System.currentTimeMillis();
         getBoard().setSkipCompletedLetters(this.prefs
                 .getBoolean("skipFilled", false));
+        movement = null;
         getBoard().setMovementStrategy(this.getMovementStrategy());
 
         int keyboardType = "CONDENSED_ARROWS".equals(prefs.getString(

--- a/app/src/main/java/com/totsp/crossword/SettingsActivity.java
+++ b/app/src/main/java/com/totsp/crossword/SettingsActivity.java
@@ -1,6 +1,9 @@
 package com.totsp.crossword;
 
 import android.os.Bundle;
+import android.view.MenuItem;
+
+import androidx.annotation.NonNull;
 
 import com.totsp.crossword.shortyz.R;
 
@@ -29,5 +32,12 @@ public class SettingsActivity extends ShortyzActivity {
         }
     }
 
-
+    @Override
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+            return true;
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
When you change this setting it's not reflected until the app is restarted
which initially made me think it wasn't working. Additionally the up/back arrow
in settings does nothing so I've made that just go back.

Possibly the onResume/onStart code could be refactored a bit more. I'd have a go
if you wanted.